### PR TITLE
EIP-0000 common schema conventions

### DIFF
--- a/docs/EIP-0000-common-types.md
+++ b/docs/EIP-0000-common-types.md
@@ -1,0 +1,59 @@
+# EIP-0000 Common Types
+
+EIP-0000 defines the shared schema conventions used by all v1 EIP artifacts.
+The reusable JSON Schema definitions live in
+`schemas/eip.common.v1.schema.json`.
+
+## Identifier Conventions
+
+An artifact id identifies the artifact itself. Each artifact schema has exactly
+one artifact id field that names the primary artifact record.
+
+reference IDs point at other protocol records. ActorRef, SourceRef,
+WorkItemRef, ChangeRequestRef, and EvidenceBundleRef are references. They do
+not redefine the referenced record and must not be treated as proof that the
+referenced record exists or is authorized.
+
+All common identifiers use `PrefixedId`: a lowercase semantic prefix, an
+underscore, and an opaque suffix. The prefix states the identifier family; the
+suffix is opaque and must not be parsed for tenant, repository, account, issue,
+environment, or authorization facts.
+
+## Timestamp Conventions
+
+v1 artifacts use explicit artifact field names for time values. Generic
+`timestamp` fields are not used in v1 because they do not identify which
+lifecycle event they describe.
+
+Timestamps use `IsoDateTimeUtc`: ISO 8601 extended date-time strings with a
+literal `Z` UTC offset. Local offsets are not accepted in common v1 fixtures.
+
+## Event Identifier Conventions
+
+Generic `eventId` fields are not used in v1 common conventions. Event-producing
+artifacts must define an artifact-specific primary id instead of inheriting a
+global event id alias.
+
+## Primary ID Aliases
+
+artifact-specific primary ID aliases are not used in v1. Schemas should choose
+one primary artifact id field and use reference types for links to other
+records.
+
+## Common Reference Types
+
+ActorRef identifies the actor associated with an artifact. It requires an
+explicit actorId and actorType.
+
+SourceRef identifies the source system or fixture family that produced the
+artifact. It requires an explicit sourceId and sourceType.
+
+WorkItemRef, ChangeRequestRef, and EvidenceBundleRef link to their respective
+protocol records by explicit reference id fields.
+
+ErrorInfo carries structured failure information. Error codes are stable,
+uppercase protocol tokens. Messages are diagnostic text and are not stable
+machine contracts.
+
+ExtensionMap is reserved for extension data. Extension keys must start with
+`x-` so extension fields cannot be confused with future core fields.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,6 @@ Start here:
 - `versioning.md` defines versioning expectations.
 - `compatibility.md` defines compatibility and deprecation rules.
 - `security.md` defines security posture for protocol artifacts.
+- `EIP-0000-common-types.md` defines common v1 schema types.
+- `data-classification.md` defines fixture and production data handling labels.
+- `idempotency.md` defines common correlation and retry conventions.

--- a/docs/data-classification.md
+++ b/docs/data-classification.md
@@ -1,0 +1,34 @@
+# Data Classification
+
+EIP artifacts carry a DataClassification value so producers and consumers can
+apply appropriate handling rules.
+
+## Classification Values
+
+- `public`: safe for checked-in fixtures, examples, documentation, and public
+  conformance tests.
+- `internal`: intended for routine internal protocol operations, but not for
+  public fixtures.
+- `confidential`: contains business-sensitive or user-sensitive production
+  message data.
+- `restricted`: contains highly sensitive production message data that requires
+  the strictest supported handling.
+
+## Fixture Data
+
+public fixture data is synthetic, non-secret, and safe to publish in this
+repository. Fixtures must not contain production identifiers, private customer
+content, real credentials, access tokens, or host-local absolute paths.
+
+Fixtures may resemble production message data structurally, but their values
+must remain synthetic and must use `public` classification unless a test is
+explicitly validating rejection of another value.
+
+## Production Message Data
+
+production message data may contain customer, tenant, account, repository,
+workflow, or operational context. It must not be copied into this repository as
+fixtures or examples.
+
+Schemas define how production message data is shaped. They do not grant
+permission to publish production message values.

--- a/docs/idempotency.md
+++ b/docs/idempotency.md
@@ -1,0 +1,18 @@
+# Idempotency
+
+EIP v1 uses CorrelationId to connect retries, related artifacts, and downstream
+diagnostics without treating those records as the same artifact.
+
+CorrelationId is not an authorization token, tenant binding, or primary
+artifact id. Consumers must not infer scope or permission from a CorrelationId
+value.
+
+When a producer retries the same logical operation, it should reuse the same
+CorrelationId and preserve the artifact-specific primary id rules for the
+artifact being produced. Consumers that need idempotent behavior must combine
+CorrelationId with the authoritative artifact type and scope record for that
+contract.
+
+If required provenance or scope bindings are missing, malformed, or only
+partially trusted, consumers should fail closed instead of accepting a guessed
+idempotency match.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -4,3 +4,6 @@ This directory is reserved for EIP contract fixtures.
 
 Fixtures should be minimal examples that prove protocol behavior. Use
 placeholders for credentials, tenants, hosts, and operator-specific values.
+
+- `common/v1/valid/` contains valid EIP-0000 common type fixtures.
+- `common/v1/invalid/` contains negative fixtures that must fail validation.

--- a/fixtures/common/v1/invalid/bad-classification.json
+++ b/fixtures/common/v1/invalid/bad-classification.json
@@ -1,0 +1,23 @@
+{
+  "artifactId": "artifact_commonEnvelope001",
+  "correlationId": "corr_commonTypes0001",
+  "createdAt": "2026-04-29T01:00:00Z",
+  "actor": {
+    "actorId": "actor_service0001",
+    "actorType": "service"
+  },
+  "source": {
+    "sourceId": "source_fixture0001",
+    "sourceType": "fixture"
+  },
+  "workItem": {
+    "workItemId": "work-item_protocol0001"
+  },
+  "changeRequest": {
+    "changeRequestId": "change-request_issue0003"
+  },
+  "evidenceBundle": {
+    "evidenceBundleId": "evidence-bundle_common0001"
+  },
+  "classification": "secret"
+}

--- a/fixtures/common/v1/invalid/bad-extension-key.json
+++ b/fixtures/common/v1/invalid/bad-extension-key.json
@@ -1,0 +1,26 @@
+{
+  "artifactId": "artifact_commonEnvelope001",
+  "correlationId": "corr_commonTypes0001",
+  "createdAt": "2026-04-29T01:00:00Z",
+  "actor": {
+    "actorId": "actor_service0001",
+    "actorType": "service"
+  },
+  "source": {
+    "sourceId": "source_fixture0001",
+    "sourceType": "fixture"
+  },
+  "workItem": {
+    "workItemId": "work-item_protocol0001"
+  },
+  "changeRequest": {
+    "changeRequestId": "change-request_issue0003"
+  },
+  "evidenceBundle": {
+    "evidenceBundleId": "evidence-bundle_common0001"
+  },
+  "classification": "public",
+  "extensions": {
+    "fixture-note": "missing required x- prefix"
+  }
+}

--- a/fixtures/common/v1/invalid/bad-timestamp.json
+++ b/fixtures/common/v1/invalid/bad-timestamp.json
@@ -1,0 +1,23 @@
+{
+  "artifactId": "artifact_commonEnvelope001",
+  "correlationId": "corr_commonTypes0001",
+  "createdAt": "2026-04-29T01:00:00+09:00",
+  "actor": {
+    "actorId": "actor_service0001",
+    "actorType": "service"
+  },
+  "source": {
+    "sourceId": "source_fixture0001",
+    "sourceType": "fixture"
+  },
+  "workItem": {
+    "workItemId": "work-item_protocol0001"
+  },
+  "changeRequest": {
+    "changeRequestId": "change-request_issue0003"
+  },
+  "evidenceBundle": {
+    "evidenceBundleId": "evidence-bundle_common0001"
+  },
+  "classification": "public"
+}

--- a/fixtures/common/v1/invalid/missing-actor-binding.json
+++ b/fixtures/common/v1/invalid/missing-actor-binding.json
@@ -1,0 +1,22 @@
+{
+  "artifactId": "artifact_commonEnvelope001",
+  "correlationId": "corr_commonTypes0001",
+  "createdAt": "2026-04-29T01:00:00Z",
+  "actor": {
+    "actorType": "service"
+  },
+  "source": {
+    "sourceId": "source_fixture0001",
+    "sourceType": "fixture"
+  },
+  "workItem": {
+    "workItemId": "work-item_protocol0001"
+  },
+  "changeRequest": {
+    "changeRequestId": "change-request_issue0003"
+  },
+  "evidenceBundle": {
+    "evidenceBundleId": "evidence-bundle_common0001"
+  },
+  "classification": "public"
+}

--- a/fixtures/common/v1/valid/common-envelope.json
+++ b/fixtures/common/v1/valid/common-envelope.json
@@ -1,0 +1,39 @@
+{
+  "artifactId": "artifact_commonEnvelope001",
+  "correlationId": "corr_commonTypes0001",
+  "createdAt": "2026-04-29T01:00:00Z",
+  "actor": {
+    "actorId": "actor_service0001",
+    "actorType": "service",
+    "displayName": "Fixture Producer"
+  },
+  "source": {
+    "sourceId": "source_fixture0001",
+    "sourceType": "fixture",
+    "externalRef": "public-fixture/common-envelope"
+  },
+  "workItem": {
+    "workItemId": "work-item_protocol0001",
+    "title": "Define common schema conventions"
+  },
+  "changeRequest": {
+    "changeRequestId": "change-request_issue0003",
+    "status": "open"
+  },
+  "evidenceBundle": {
+    "evidenceBundleId": "evidence-bundle_common0001",
+    "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "classification": "public",
+  "error": {
+    "code": "VALIDATION_FAILED",
+    "message": "Example error payload for contract validation.",
+    "retryable": false,
+    "details": {
+      "field": "artifactId"
+    }
+  },
+  "extensions": {
+    "x-fixture-note": "public example only"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "devDependencies": {
         "@types/node": "^20.12.12",
+        "ajv": "^8.20.0",
         "tsx": "^4.19.2",
         "typescript": "^5.4.5",
         "vitest": "^4.1.5"
@@ -956,6 +957,23 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1062,6 +1080,30 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1107,6 +1149,13 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1463,6 +1512,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.12",
+    "ajv": "^8.20.0",
     "tsx": "^4.19.2",
     "typescript": "^5.4.5",
     "vitest": "^4.1.5"

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -4,3 +4,6 @@ This directory is reserved for machine-readable EIP contract schemas.
 
 Schemas added here should be versioned, documented, and covered by fixtures or
 tests that demonstrate their intended interoperability behavior.
+
+- `eip.common.v1.schema.json` defines reusable v1 common types and a fixture
+  envelope used by common-type conformance tests.

--- a/schemas/eip.common.v1.schema.json
+++ b/schemas/eip.common.v1.schema.json
@@ -65,7 +65,7 @@
     "IsoDateTimeUtc": {
       "type": "string",
       "description": "UTC timestamp using ISO 8601 extended format with a literal Z offset.",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?Z$"
     },
     "ActorRef": {
       "type": "object",
@@ -195,7 +195,7 @@
       "type": "object",
       "description": "Vendor or artifact-specific extension values. Extension keys must use the x- prefix.",
       "propertyNames": {
-        "pattern": "^x-[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        "pattern": "^x-.+$"
       },
       "additionalProperties": true
     },

--- a/schemas/eip.common.v1.schema.json
+++ b/schemas/eip.common.v1.schema.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.common.v1.schema.json",
+  "title": "EIP Common v1 Fixture Envelope",
+  "description": "Common schema conventions and reusable v1 type definitions for EIP artifacts.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "artifactId",
+    "correlationId",
+    "createdAt",
+    "actor",
+    "source",
+    "workItem",
+    "changeRequest",
+    "evidenceBundle",
+    "classification"
+  ],
+  "properties": {
+    "artifactId": {
+      "$ref": "#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "#/$defs/CorrelationId"
+    },
+    "createdAt": {
+      "$ref": "#/$defs/IsoDateTimeUtc"
+    },
+    "actor": {
+      "$ref": "#/$defs/ActorRef"
+    },
+    "source": {
+      "$ref": "#/$defs/SourceRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/WorkItemRef"
+    },
+    "changeRequest": {
+      "$ref": "#/$defs/ChangeRequestRef"
+    },
+    "evidenceBundle": {
+      "$ref": "#/$defs/EvidenceBundleRef"
+    },
+    "classification": {
+      "$ref": "#/$defs/DataClassification"
+    },
+    "error": {
+      "$ref": "#/$defs/ErrorInfo"
+    },
+    "extensions": {
+      "$ref": "#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "PrefixedId": {
+      "type": "string",
+      "description": "Stable protocol identifier with a lowercase semantic prefix, underscore separator, and opaque suffix.",
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$"
+    },
+    "CorrelationId": {
+      "type": "string",
+      "description": "Opaque idempotency and tracing identifier shared by related protocol artifacts.",
+      "pattern": "^corr_[A-Za-z0-9][A-Za-z0-9._~-]{11,127}$"
+    },
+    "IsoDateTimeUtc": {
+      "type": "string",
+      "description": "UTC timestamp using ISO 8601 extended format with a literal Z offset.",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d{3})?Z$"
+    },
+    "ActorRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["actorId", "actorType"],
+      "properties": {
+        "actorId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "actorType": {
+          "type": "string",
+          "enum": ["human", "service", "system"]
+        },
+        "displayName": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 160
+        }
+      }
+    },
+    "SourceRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sourceId", "sourceType"],
+      "properties": {
+        "sourceId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "sourceType": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "WorkItemRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "ChangeRequestRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["changeRequestId"],
+      "properties": {
+        "changeRequestId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "open", "accepted", "rejected", "superseded"]
+        }
+      }
+    },
+    "EvidenceBundleRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["evidenceBundleId"],
+      "properties": {
+        "evidenceBundleId": {
+          "$ref": "#/$defs/PrefixedId"
+        },
+        "digest": {
+          "type": "string",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        }
+      }
+    },
+    "ErrorInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        },
+        "retryable": {
+          "type": "boolean"
+        },
+        "details": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ExtensionMap": {
+      "type": "object",
+      "description": "Vendor or artifact-specific extension values. Extension keys must use the x- prefix.",
+      "propertyNames": {
+        "pattern": "^x-[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+      },
+      "additionalProperties": true
+    },
+    "DataClassification": {
+      "type": "string",
+      "description": "Classification label for fixture and production data handling.",
+      "enum": ["public", "internal", "confidential", "restricted"]
+    }
+  }
+}

--- a/test/common-schema.test.ts
+++ b/test/common-schema.test.ts
@@ -28,6 +28,15 @@ function fixturePaths(directory: string): string[] {
     .sort();
 }
 
+function commonEnvelope(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const fixture = readJson("fixtures/common/v1/valid/common-envelope.json");
+
+  return {
+    ...(fixture as Record<string, unknown>),
+    ...overrides,
+  };
+}
+
 describe("EIP-0000 common schema", () => {
   const schema = readJson(schemaPath);
   const ajv = new Ajv2020({ allErrors: true, strict: true });
@@ -57,6 +66,47 @@ describe("EIP-0000 common schema", () => {
     "rejects invalid fixture %s",
     (fixturePath) => {
       const fixture = readJson(fixturePath);
+
+      expect(validate(fixture)).toBe(false);
+    }
+  );
+
+  it.each([
+    "2026-04-29T01:00:00Z",
+    "2026-04-29T01:00:00.1Z",
+    "2026-04-29T01:00:00.123456Z",
+  ])("accepts UTC timestamps with optional fractional seconds: %s", (createdAt) => {
+    expect(
+      validate(commonEnvelope({ createdAt })),
+      JSON.stringify(validate.errors, null, 2)
+    ).toBe(true);
+  });
+
+  it.each(["2026-04-29T01:00:00.Z", "2026-04-29T01:00:00.123456+00:00"])(
+    "rejects malformed or non-Z UTC timestamps: %s",
+    (createdAt) => {
+      expect(validate(commonEnvelope({ createdAt }))).toBe(false);
+    }
+  );
+
+  it("accepts any non-empty extension key that starts with x-", () => {
+    const fixture = commonEnvelope({
+      extensions: {
+        "x-Vendor.Field": "extension values are artifact-specific",
+      },
+    });
+
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(["x-", "fixture-note"])(
+    "rejects extension keys that do not use a non-empty x- prefix: %s",
+    (key) => {
+      const fixture = commonEnvelope({
+        extensions: {
+          [key]: "invalid extension key",
+        },
+      });
 
       expect(validate(fixture)).toBe(false);
     }

--- a/test/common-schema.test.ts
+++ b/test/common-schema.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas/eip.common.v1.schema.json");
+const validFixturesDir = path.join(repoRoot, "fixtures/common/v1/valid");
+const invalidFixturesDir = path.join(repoRoot, "fixtures/common/v1/invalid");
+
+function readJson(relativeOrAbsolutePath: string): unknown {
+  const filePath = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(repoRoot, relativeOrAbsolutePath);
+
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+function readMarkdown(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fixturePaths(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(directory, entry))
+    .sort();
+}
+
+describe("EIP-0000 common schema", () => {
+  const schema = readJson(schemaPath);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  const validate = ajv.compile(schema);
+
+  it("defines the required common v1 types", () => {
+    expect(schema).toHaveProperty("$defs.PrefixedId");
+    expect(schema).toHaveProperty("$defs.CorrelationId");
+    expect(schema).toHaveProperty("$defs.IsoDateTimeUtc");
+    expect(schema).toHaveProperty("$defs.ActorRef");
+    expect(schema).toHaveProperty("$defs.SourceRef");
+    expect(schema).toHaveProperty("$defs.WorkItemRef");
+    expect(schema).toHaveProperty("$defs.ChangeRequestRef");
+    expect(schema).toHaveProperty("$defs.EvidenceBundleRef");
+    expect(schema).toHaveProperty("$defs.ErrorInfo");
+    expect(schema).toHaveProperty("$defs.ExtensionMap");
+    expect(schema).toHaveProperty("$defs.DataClassification");
+  });
+
+  it.each(fixturePaths(validFixturesDir))("accepts valid fixture %s", (fixturePath) => {
+    const fixture = readJson(fixturePath);
+
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(fixturePaths(invalidFixturesDir))(
+    "rejects invalid fixture %s",
+    (fixturePath) => {
+      const fixture = readJson(fixturePath);
+
+      expect(validate(fixture)).toBe(false);
+    }
+  );
+});
+
+describe("EIP-0000 common docs", () => {
+  it("documents id, timestamp, and data classification conventions", () => {
+    const commonTypes = readMarkdown("docs/EIP-0000-common-types.md");
+    const dataClassification = readMarkdown("docs/data-classification.md");
+    const idempotency = readMarkdown("docs/idempotency.md");
+
+    expect(commonTypes).toContain("artifact id");
+    expect(commonTypes).toContain("reference IDs");
+    expect(commonTypes).toContain("timestamp");
+    expect(commonTypes).toContain("eventId");
+    expect(commonTypes).toContain("artifact-specific primary ID aliases");
+    expect(dataClassification).toContain("public fixture data");
+    expect(dataClassification).toContain("production message data");
+    expect(idempotency).toContain("CorrelationId");
+  });
+});


### PR DESCRIPTION
## Summary
- define the EIP-0000 common v1 JSON Schema and reusable common type definitions
- add common type docs for identifiers, timestamps, data classification, and idempotency
- add valid and invalid common fixtures with focused AJV validation coverage

## Verification
- npm test -- test/common-schema.test.ts
- npm test
- npm run check:spec-boundary

Refs #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on common schema types, identifier/timestamp conventions, data classification, idempotency/CorrelationId, and updated docs index and fixtures README.

* **New Features**
  * Added a JSON Schema for EIP v1 common types and artifact envelopes.

* **Fixtures**
  * Added valid and invalid fixture cases for classification, extension keys, timestamps, and missing bindings.

* **Tests**
  * Added schema conformance tests validating fixtures and documentation conventions.

* **Chores**
  * Added AJV to development dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->