### PR TITLE
EIP-0001: Define RunRequest v1 schema

### DIFF
--- a/docs/EIP-0001-run-request.md
+++ b/docs/EIP-0001-run-request.md
@@ -1,0 +1,61 @@
+# EIP-0001 RunRequest v1
+
+RunRequest v1 defines the transport-neutral request artifact used to ask an
+Ensen-compatible executor to run work. The machine-readable schema lives in
+`schemas/eip.run-request.v1.schema.json`.
+
+RunRequest is a contract document, not an executor API, queue format, webhook
+handler, connector implementation, or runtime service.
+
+## Required Fields
+
+- `schemaVersion`: must be `eip.run-request.v1`.
+- `id`: the RunRequest artifact id.
+- `correlationId`: shared tracing and retry correlation id.
+- `idempotencyKey`: producer-assigned key for the same logical request.
+- `source`: object identifying the source system that produced the request.
+- `requestedBy`: actor that requested or dispatched the work.
+- `workItem`: work item reference for the requested work.
+- `mode`: requested executor mode: `plan`, `apply`, or `validate`.
+- `createdAt`: UTC creation time for the request artifact.
+
+## Optional Fields
+
+- `target`: explicit repository, workspace, environment, or manual target.
+- `policyContext`: policy set and risk-class hints for enforcement.
+- `dataClassification`: common v1 classification label.
+- `extensions`: `x-` prefixed extension map.
+
+Top-level fields outside the schema are rejected. Extension data must stay under
+`extensions` and must use `x-` prefixed keys so future core fields remain
+unambiguous.
+
+## Source and Work Item Binding
+
+`source` is always an object using the common v1 SourceRef shape. A string such
+as `"github"` is not enough because it cannot carry a durable source id or
+explicit external source reference.
+
+`workItem.externalId` carries the identifier used by the external source system,
+such as a GitHub issue number or a manual intake ticket. Consumers must not
+derive repository, tenant, account, authorization, or environment bindings from
+the external id alone. Those bindings must come from authoritative scope records
+outside this artifact.
+
+## Idempotency
+
+Producers should reuse the same `idempotencyKey` when retrying the same logical
+RunRequest after a transport timeout, queue retry, or dispatcher restart.
+Consumers should use the tuple of artifact type, authoritative scope record, and
+`idempotencyKey` to detect duplicate logical requests.
+
+`correlationId` remains useful for tracing related artifacts, but it is not a
+deduplication key by itself and is not an authorization token. If the scope
+record, requester, source, or required provenance is missing or malformed,
+consumers should fail closed instead of accepting a guessed idempotency match.
+
+## Fixture Safety
+
+Checked-in RunRequest fixtures must be synthetic and public. Raw credentials,
+access tokens, private customer values, and host-local absolute paths are not
+valid fixture content, even inside `extensions`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,5 +14,7 @@ Start here:
 - `compatibility.md` defines compatibility and deprecation rules.
 - `security.md` defines security posture for protocol artifacts.
 - `EIP-0000-common-types.md` defines common v1 schema types.
+- `EIP-0001-run-request.md` defines the RunRequest v1 executor request
+  contract.
 - `data-classification.md` defines fixture and production data handling labels.
 - `idempotency.md` defines common correlation and retry conventions.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -7,3 +7,6 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
 
 - `common/v1/valid/` contains valid EIP-0000 common type fixtures.
 - `common/v1/invalid/` contains negative fixtures that must fail validation.
+- `run-request/v1/valid/` contains valid EIP-0001 RunRequest fixtures.
+- `run-request/v1/invalid/` contains negative RunRequest fixtures and fixture
+  safety examples.

--- a/fixtures/run-request/v1/invalid/bad-schema-version.json
+++ b/fixtures/run-request/v1/invalid/bad-schema-version.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": "eip.run-request.v2",
+  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2CB",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2CC",
+    "sourceType": "github"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2CD",
+    "actorType": "service"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2CE",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z"
+}

--- a/fixtures/run-request/v1/invalid/raw-secret.json
+++ b/fixtures/run-request/v1/invalid/raw-secret.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2DB",
+  "idempotencyKey": "manual-request-20260429-2",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2DC",
+    "sourceType": "manual"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2DD",
+    "actorType": "human"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2DE",
+    "externalId": "manual-secret-check"
+  },
+  "mode": "validate",
+  "createdAt": "2026-04-29T02:00:00Z",
+  "extensions": {
+    "x-raw-secret": "ghp_0123456789abcdefghijklmnopqrstuvwxyz"
+  }
+}

--- a/fixtures/run-request/v1/invalid/raw-secret.json
+++ b/fixtures/run-request/v1/invalid/raw-secret.json
@@ -18,6 +18,6 @@
   "mode": "validate",
   "createdAt": "2026-04-29T02:00:00Z",
   "extensions": {
-    "x-raw-secret": "ghp_0123456789abcdefghijklmnopqrstuvwxyz"
+    "x-raw-secret": "REDACTED_FIXTURE_SECRET_PLACEHOLDER"
   }
 }

--- a/fixtures/run-request/v1/invalid/source-string.json
+++ b/fixtures/run-request/v1/invalid/source-string.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2EA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2EB",
+  "idempotencyKey": "manual-request-20260429-3",
+  "source": "github",
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2EC",
+    "actorType": "service"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2ED",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z"
+}

--- a/fixtures/run-request/v1/invalid/unknown-top-level-field.json
+++ b/fixtures/run-request/v1/invalid/unknown-top-level-field.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2FA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2FB",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2FC",
+    "sourceType": "github"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2FD",
+    "actorType": "service"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2FE",
+    "externalId": "4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z",
+  "transport": "github-webhook"
+}

--- a/fixtures/run-request/v1/valid/github-issue-request.json
+++ b/fixtures/run-request/v1/valid/github-issue-request.json
@@ -2,7 +2,7 @@
   "schemaVersion": "eip.run-request.v1",
   "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
-  "idempotencyKey": "github-issue-4-attempt-1",
+  "idempotencyKey": "github-issue-4",
   "source": {
     "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
     "sourceType": "github",

--- a/fixtures/run-request/v1/valid/github-issue-request.json
+++ b/fixtures/run-request/v1/valid/github-issue-request.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "idempotencyKey": "github-issue-4-attempt-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2AD",
+    "sourceType": "github",
+    "externalRef": "TommyKammy/Ensen-protocol"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "service",
+    "displayName": "Ensen issue dispatcher"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2AF",
+    "externalId": "4",
+    "title": "EIP-0001: Define RunRequest v1 schema",
+    "url": "https://github.com/TommyKammy/Ensen-protocol/issues/4"
+  },
+  "mode": "plan",
+  "createdAt": "2026-04-29T01:45:45Z",
+  "target": {
+    "targetType": "repository",
+    "targetId": "repo_01HV7Y8M8F2KQ5W3P9R6T4N2AG",
+    "externalRef": "TommyKammy/Ensen-protocol"
+  },
+  "policyContext": {
+    "policySetId": "policy_01HV7Y8M8F2KQ5W3P9R6T4N2AH",
+    "riskClasses": ["secrets"],
+    "requiresApproval": true
+  },
+  "dataClassification": "public",
+  "extensions": {
+    "x-fixture-note": "synthetic GitHub issue request"
+  }
+}

--- a/fixtures/run-request/v1/valid/manual-request.json
+++ b/fixtures/run-request/v1/valid/manual-request.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": "eip.run-request.v1",
+  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  "idempotencyKey": "manual-request-20260429-1",
+  "source": {
+    "sourceId": "source_01HV7Y8M8F2KQ5W3P9R6T4N2BC",
+    "sourceType": "manual",
+    "externalRef": "operator-intake"
+  },
+  "requestedBy": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2BD",
+    "actorType": "human",
+    "displayName": "Example Operator"
+  },
+  "workItem": {
+    "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2BE",
+    "externalId": "manual-2026-04-29-001",
+    "title": "Review protocol fixture coverage"
+  },
+  "mode": "validate",
+  "createdAt": "2026-04-29T02:00:00Z",
+  "dataClassification": "public"
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -7,3 +7,5 @@ tests that demonstrate their intended interoperability behavior.
 
 - `eip.common.v1.schema.json` defines reusable v1 common types and a fixture
   envelope used by common-type conformance tests.
+- `eip.run-request.v1.schema.json` defines the transport-neutral RunRequest v1
+  contract for executor requests.

--- a/schemas/eip.run-request.v1.schema.json
+++ b/schemas/eip.run-request.v1.schema.json
@@ -1,0 +1,134 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-request.v1.schema.json",
+  "title": "EIP-0001 RunRequest v1",
+  "description": "Transport-neutral request contract for asking an Ensen-compatible executor to run work.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "idempotencyKey",
+    "source",
+    "requestedBy",
+    "workItem",
+    "mode",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-request.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "idempotencyKey": {
+      "type": "string",
+      "minLength": 12,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{11,159}$"
+    },
+    "source": {
+      "$ref": "eip.common.v1.schema.json#/$defs/SourceRef"
+    },
+    "requestedBy": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ActorRef"
+    },
+    "workItem": {
+      "$ref": "#/$defs/RunRequestWorkItem"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["plan", "apply", "validate"]
+    },
+    "createdAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "target": {
+      "$ref": "#/$defs/RunTarget"
+    },
+    "policyContext": {
+      "$ref": "#/$defs/PolicyContext"
+    },
+    "dataClassification": {
+      "$ref": "eip.common.v1.schema.json#/$defs/DataClassification"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunRequestWorkItem": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["workItemId", "externalId"],
+      "properties": {
+        "workItemId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "externalId": {
+          "type": "string",
+          "description": "Identifier used by the external source system, such as a GitHub issue number or manual ticket id.",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "url": {
+          "type": "string",
+          "pattern": "^https://[^\\s]+$",
+          "maxLength": 400
+        }
+      }
+    },
+    "RunTarget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["targetType", "targetId"],
+      "properties": {
+        "targetType": {
+          "type": "string",
+          "enum": ["repository", "workspace", "environment", "manual"]
+        },
+        "targetId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "PolicyContext": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policySetId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "riskClasses": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 80,
+            "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+          },
+          "uniqueItems": true,
+          "maxItems": 20
+        },
+        "requiresApproval": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/test/run-request-schema.test.ts
+++ b/test/run-request-schema.test.ts
@@ -95,8 +95,15 @@ describe("EIP-0001 RunRequest schema", () => {
     "rejects invalid fixture %s",
     (fixturePath) => {
       const fixture = readJson(fixturePath);
+      const hasRawSecret = containsRawSecret(fixture);
+      const isSchemaValid = validate(fixture);
 
-      expect(validate(fixture) && !containsRawSecret(fixture)).toBe(false);
+      if (path.basename(fixturePath) === "raw-secret.json") {
+        expect(hasRawSecret).toBe(true);
+      } else {
+        expect(hasRawSecret).toBe(false);
+        expect(isSchemaValid, JSON.stringify(validate.errors, null, 2)).toBe(false);
+      }
     }
   );
 

--- a/test/run-request-schema.test.ts
+++ b/test/run-request-schema.test.ts
@@ -1,0 +1,134 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas/eip.run-request.v1.schema.json");
+const commonSchemaPath = path.join(repoRoot, "schemas/eip.common.v1.schema.json");
+const validFixturesDir = path.join(repoRoot, "fixtures/run-request/v1/valid");
+const invalidFixturesDir = path.join(repoRoot, "fixtures/run-request/v1/invalid");
+
+function readJson(relativeOrAbsolutePath: string): unknown {
+  const filePath = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(repoRoot, relativeOrAbsolutePath);
+
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+function readMarkdown(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fixturePaths(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(directory, entry))
+    .sort();
+}
+
+function runRequest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const fixture = readJson("fixtures/run-request/v1/valid/github-issue-request.json");
+
+  return {
+    ...(fixture as Record<string, unknown>),
+    ...overrides,
+  };
+}
+
+function containsRawSecret(value: unknown): boolean {
+  if (typeof value === "string") {
+    return /(ghp_[A-Za-z0-9]{20,}|-----BEGIN [A-Z ]*PRIVATE KEY-----|AKIA[0-9A-Z]{16})/.test(
+      value
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsRawSecret(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.entries(value).some(
+      ([key, nested]) =>
+        /(?:secret|token|password|privateKey)/i.test(key) || containsRawSecret(nested)
+    );
+  }
+
+  return false;
+}
+
+describe("EIP-0001 RunRequest schema", () => {
+  const schema = readJson(schemaPath);
+  const commonSchema = readJson(commonSchemaPath);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(commonSchema, "eip.common.v1.schema.json");
+  const validate = ajv.compile(schema);
+
+  it("requires the RunRequest v1 contract fields", () => {
+    expect(schema).toHaveProperty("required", [
+      "schemaVersion",
+      "id",
+      "correlationId",
+      "idempotencyKey",
+      "source",
+      "requestedBy",
+      "workItem",
+      "mode",
+      "createdAt",
+    ]);
+    expect(schema).toHaveProperty("properties.target");
+    expect(schema).toHaveProperty("properties.policyContext");
+    expect(schema).toHaveProperty("properties.dataClassification");
+    expect(schema).toHaveProperty("properties.extensions");
+  });
+
+  it.each(fixturePaths(validFixturesDir))("accepts valid fixture %s", (fixturePath) => {
+    const fixture = readJson(fixturePath);
+
+    expect(containsRawSecret(fixture)).toBe(false);
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(fixturePaths(invalidFixturesDir))(
+    "rejects invalid fixture %s",
+    (fixturePath) => {
+      const fixture = readJson(fixturePath);
+
+      expect(validate(fixture) && !containsRawSecret(fixture)).toBe(false);
+    }
+  );
+
+  it("rejects unknown top-level fields", () => {
+    expect(validate(runRequest({ unexpected: true }))).toBe(false);
+  });
+
+  it("requires source to be an object", () => {
+    expect(validate(runRequest({ source: "github" }))).toBe(false);
+  });
+
+  it("uses workItem.externalId for external system identifiers", () => {
+    const fixture = runRequest();
+
+    expect(fixture.workItem).toHaveProperty("externalId", "4");
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it("rejects raw secret fixture content with the fixture safety check", () => {
+    const fixture = readJson("fixtures/run-request/v1/invalid/raw-secret.json");
+
+    expect(containsRawSecret(fixture)).toBe(true);
+  });
+});
+
+describe("EIP-0001 RunRequest docs", () => {
+  it("documents idempotency behavior and fixture safety", () => {
+    const docs = readMarkdown("docs/EIP-0001-run-request.md");
+
+    expect(docs).toContain("idempotencyKey");
+    expect(docs).toContain("Consumers should use the tuple");
+    expect(docs).toContain("fail closed");
+    expect(docs).toContain("Raw credentials");
+  });
+});


### PR DESCRIPTION
## Summary
- add the transport-neutral RunRequest v1 schema
- add valid and invalid RunRequest fixtures, including raw-secret safety coverage
- document EIP-0001 idempotency and fixture-safety expectations

## Verification
- npm test -- test/run-request-schema.test.ts
- npm test
- npm run check:spec-boundary
- npm audit --omit=optional

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EIP-0001 RunRequest v1 specification document defining the contract artifact with required and optional fields, validation rules, and safety guidelines for test fixtures.
  * Updated documentation index to reference the new RunRequest specification.
  * Added JSON Schema for RunRequest v1 transport-neutral contract.

* **Tests**
  * Added comprehensive test suite validating RunRequest v1 schema compliance against fixture examples and safety checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->