### PR TITLE
EIP-0002: Define RunResult v1 schema

### DIFF
--- a/docs/EIP-0002-run-result.md
+++ b/docs/EIP-0002-run-result.md
@@ -1,0 +1,66 @@
+# EIP-0002 RunResult v1
+
+RunResult v1 defines the transport-neutral terminal result artifact produced
+after an Ensen-compatible executor finishes a run. The machine-readable schema
+lives in `schemas/eip.run-result.v1.schema.json`.
+
+RunResult is a contract document, not an async polling API, queue state format,
+runtime service, connector implementation, or workflow engine.
+
+## Required Fields
+
+- `schemaVersion`: must be `eip.run-result.v1`.
+- `id`: the RunResult artifact id.
+- `requestId`: the RunRequest artifact id this result completes.
+- `correlationId`: shared tracing and retry correlation id.
+- `status`: final run status.
+- `completedAt`: UTC completion time for the result artifact.
+
+## Final Statuses
+
+RunResult only represents final statuses:
+
+- `succeeded`: the run completed successfully.
+- `failed`: the run attempted work and failed.
+- `blocked`: the run stopped because a required prerequisite was missing.
+- `needs_review`: the run completed but requires human review before the
+  downstream outcome can be trusted or applied.
+- `cancelled`: the run was intentionally stopped before completion.
+
+The in-progress states `queued` and `running` are not valid RunResult statuses.
+Producers that need to expose those states should use a RunStatusSnapshot
+artifact instead of emitting a RunResult early.
+
+## Optional Fields
+
+- `changeRequests`: zero or more common v1 ChangeRequestRef objects produced or
+  updated by the run.
+- `evidenceBundles`: zero or more common v1 EvidenceBundleRef objects that
+  anchor logs, test results, review evidence, or other durable proof.
+- `verification`: summary of verification commands and their outcomes.
+- `errors`: machine-readable errors using the common v1 ErrorInfo shape.
+- `warnings`: non-fatal diagnostics.
+- `metrics`: bounded run metrics such as duration, attempts, and token counts.
+- `extensions`: `x-` prefixed extension map.
+
+Top-level fields outside the schema are rejected. Extension data must stay under
+`extensions` and must use `x-` prefixed keys so future core fields remain
+unambiguous.
+
+## Request Binding
+
+`requestId` is the explicit binding to the RunRequest that this result
+completes. Consumers must not infer repository, tenant, account, authorization,
+or environment linkage from id shape, branch names, issue numbers, or
+operator-facing summaries. Those bindings must come from authoritative scope
+records outside this artifact.
+
+When `requestId`, `correlationId`, provenance, or scope context is missing or
+malformed, consumers should fail closed instead of accepting a guessed match.
+
+## Fixture Safety
+
+Checked-in RunResult fixtures must be synthetic and public. Raw credentials,
+access tokens, private customer values, and host-local absolute paths are not
+valid fixture content, even inside `extensions`, `errors`, `warnings`, or
+verification summaries.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -10,3 +10,5 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
 - `run-request/v1/valid/` contains valid EIP-0001 RunRequest fixtures.
 - `run-request/v1/invalid/` contains negative RunRequest fixtures and fixture
   safety examples.
+- `run-result/v1/valid/` contains valid EIP-0002 RunResult fixtures.
+- `run-result/v1/invalid/` contains negative RunResult fixtures.

--- a/fixtures/run-result/v1/invalid/missing-request-id.json
+++ b/fixtures/run-result/v1/invalid/missing-request-id.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "status": "succeeded",
+  "completedAt": "2026-04-29T03:00:00Z"
+}

--- a/fixtures/run-result/v1/invalid/running-status.json
+++ b/fixtures/run-result/v1/invalid/running-status.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9X",
+  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9Y",
+  "status": "running",
+  "completedAt": "2026-04-29T03:10:00Z"
+}

--- a/fixtures/run-result/v1/valid/blocked-result.json
+++ b/fixtures/run-result/v1/valid/blocked-result.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
+  "status": "blocked",
+  "completedAt": "2026-04-29T02:40:00Z",
+  "verification": {
+    "status": "blocked",
+    "summary": "Required approval was not available."
+  },
+  "warnings": [
+    {
+      "code": "APPROVAL_REQUIRED",
+      "message": "The run stopped before making changes because approval was required."
+    }
+  ],
+  "metrics": {
+    "durationMs": 30000,
+    "attempts": 1
+  }
+}

--- a/fixtures/run-result/v1/valid/failed-result.json
+++ b/fixtures/run-result/v1/valid/failed-result.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "status": "failed",
+  "completedAt": "2026-04-29T02:50:00Z",
+  "verification": {
+    "status": "failed",
+    "commands": [
+      {
+        "command": "npm test",
+        "status": "failed",
+        "completedAt": "2026-04-29T02:49:50Z",
+        "summary": "A schema validation test failed."
+      }
+    ],
+    "summary": "Run failed during verification."
+  },
+  "errors": [
+    {
+      "code": "VERIFICATION_FAILED",
+      "message": "Focused verification failed.",
+      "retryable": true
+    }
+  ],
+  "metrics": {
+    "durationMs": 120000,
+    "attempts": 2
+  }
+}

--- a/fixtures/run-result/v1/valid/succeeded-result.json
+++ b/fixtures/run-result/v1/valid/succeeded-result.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "eip.run-result.v1",
+  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
+  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "status": "succeeded",
+  "completedAt": "2026-04-29T02:30:00Z",
+  "changeRequests": [
+    {
+      "changeRequestId": "changereq_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      "status": "open"
+    }
+  ],
+  "evidenceBundles": [
+    {
+      "evidenceBundleId": "evidence_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    }
+  ],
+  "verification": {
+    "status": "passed",
+    "commands": [
+      {
+        "command": "npm test",
+        "status": "passed",
+        "completedAt": "2026-04-29T02:29:45Z",
+        "summary": "Contract tests passed."
+      }
+    ],
+    "summary": "Run completed and verification passed."
+  },
+  "metrics": {
+    "durationMs": 180000,
+    "attempts": 1,
+    "tokensInput": 2400,
+    "tokensOutput": 900
+  },
+  "extensions": {
+    "x-fixture-note": "synthetic succeeded result"
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -9,3 +9,5 @@ tests that demonstrate their intended interoperability behavior.
   envelope used by common-type conformance tests.
 - `eip.run-request.v1.schema.json` defines the transport-neutral RunRequest v1
   contract for executor requests.
+- `eip.run-result.v1.schema.json` defines the transport-neutral RunResult v1
+  contract for terminal executor results.

--- a/schemas/eip.run-result.v1.schema.json
+++ b/schemas/eip.run-result.v1.schema.json
@@ -1,0 +1,163 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-result.v1.schema.json",
+  "title": "EIP-0002 RunResult v1",
+  "description": "Transport-neutral terminal result contract for completed Ensen-compatible executor runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "requestId",
+    "correlationId",
+    "status",
+    "completedAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-result.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "requestId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "status": {
+      "$ref": "#/$defs/RunResultStatus"
+    },
+    "completedAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "changeRequests": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/ChangeRequestRef"
+      },
+      "maxItems": 50
+    },
+    "evidenceBundles": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/EvidenceBundleRef"
+      },
+      "maxItems": 50
+    },
+    "verification": {
+      "$ref": "#/$defs/VerificationSummary"
+    },
+    "errors": {
+      "type": "array",
+      "items": {
+        "$ref": "eip.common.v1.schema.json#/$defs/ErrorInfo"
+      },
+      "maxItems": 50
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/WarningInfo"
+      },
+      "maxItems": 50
+    },
+    "metrics": {
+      "$ref": "#/$defs/RunMetrics"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunResultStatus": {
+      "type": "string",
+      "enum": ["succeeded", "failed", "blocked", "needs_review", "cancelled"]
+    },
+    "VerificationSummary": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "blocked", "not_run"]
+        },
+        "commands": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/VerificationCommand"
+          },
+          "maxItems": 50
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "VerificationCommand": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["command", "status"],
+      "properties": {
+        "command": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        },
+        "status": {
+          "type": "string",
+          "enum": ["passed", "failed", "blocked", "not_run"]
+        },
+        "completedAt": {
+          "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500
+        }
+      }
+    },
+    "WarningInfo": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+        },
+        "message": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 1000
+        }
+      }
+    },
+    "RunMetrics": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "durationMs": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "attempts": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tokensInput": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "tokensOutput": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/test/run-result-schema.test.ts
+++ b/test/run-result-schema.test.ts
@@ -1,0 +1,111 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas/eip.run-result.v1.schema.json");
+const commonSchemaPath = path.join(repoRoot, "schemas/eip.common.v1.schema.json");
+const validFixturesDir = path.join(repoRoot, "fixtures/run-result/v1/valid");
+const invalidFixturesDir = path.join(repoRoot, "fixtures/run-result/v1/invalid");
+
+function readJson(relativeOrAbsolutePath: string): unknown {
+  const filePath = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(repoRoot, relativeOrAbsolutePath);
+
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+function readMarkdown(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fixturePaths(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(directory, entry))
+    .sort();
+}
+
+describe("EIP-0002 RunResult schema", () => {
+  const schema = readJson(schemaPath);
+  const commonSchema = readJson(commonSchemaPath);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(commonSchema, "eip.common.v1.schema.json");
+  const validate = ajv.compile(schema);
+
+  function runResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+    return {
+      schemaVersion: "eip.run-result.v1",
+      id: "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
+      requestId: "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      status: "succeeded",
+      completedAt: "2026-04-29T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("requires the RunResult v1 terminal contract fields", () => {
+    expect(schema).toHaveProperty("required", [
+      "schemaVersion",
+      "id",
+      "requestId",
+      "correlationId",
+      "status",
+      "completedAt",
+    ]);
+  });
+
+  it.each(fixturePaths(validFixturesDir))("accepts valid fixture %s", (fixturePath) => {
+    const fixture = readJson(fixturePath);
+
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(fixturePaths(invalidFixturesDir))(
+    "rejects invalid fixture %s",
+    (fixturePath) => {
+      const fixture = readJson(fixturePath);
+
+      expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(false);
+    }
+  );
+
+  it("accepts terminal statuses and rejects in-progress statuses", () => {
+    for (const status of ["succeeded", "failed", "blocked", "needs_review", "cancelled"]) {
+      expect(validate(runResult({ status })), JSON.stringify(validate.errors, null, 2)).toBe(
+        true
+      );
+    }
+
+    for (const status of ["queued", "running"]) {
+      expect(validate(runResult({ status }))).toBe(false);
+    }
+  });
+
+  it("supports result evidence, verification, diagnostics, and metrics", () => {
+    const fixture = readJson(
+      "fixtures/run-result/v1/valid/succeeded-result.json"
+    ) as Record<string, unknown>;
+
+    expect(fixture).toHaveProperty("changeRequests");
+    expect(fixture).toHaveProperty("evidenceBundles");
+    expect(fixture).toHaveProperty("verification");
+    expect(fixture).toHaveProperty("metrics");
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+});
+
+describe("EIP-0002 RunResult docs", () => {
+  it("documents final statuses and RunStatusSnapshot separation", () => {
+    const docs = readMarkdown("docs/EIP-0002-run-result.md");
+
+    expect(docs).toContain("queued");
+    expect(docs).toContain("running");
+    expect(docs).toContain("RunStatusSnapshot");
+    expect(docs).toContain("final statuses");
+  });
+});


### PR DESCRIPTION
## Summary
- add RunResult v1 terminal-result schema
- add EIP-0002 docs and RunResult fixture coverage
- reject queued/running states from RunResult in schema tests

## Verification
- npm test -- test/run-result-schema.test.ts
- npm test
- npm run check:spec-boundary

Part of #1
Closes #5