### PR TITLE
EIP-0003: Define AuditEvent v1 schema

### DIFF
--- a/docs/EIP-0003-audit-event.md
+++ b/docs/EIP-0003-audit-event.md
@@ -1,0 +1,73 @@
+# EIP-0003 AuditEvent v1
+
+AuditEvent v1 defines the transport-neutral event artifact for append-only audit
+and evidence streams. The machine-readable schema lives in
+`schemas/eip.audit-event.v1.schema.json`.
+
+AuditEvent is a contract document, not an audit storage service, message broker,
+runtime event emitter, workflow engine, or connector implementation.
+
+## Required Fields
+
+- `schemaVersion`: must be `eip.audit-event.v1`.
+- `id`: the AuditEvent artifact id.
+- `correlationId`: shared tracing and retry correlation id.
+- `subject`: explicit object identifying the artifact or process the event is
+  about.
+- `type`: dot-separated event type name from the registry.
+- `actor`: actor that produced or caused the event.
+- `occurredAt`: UTC time when the audited fact occurred.
+
+The legacy top-level field `timestamp` is not part of AuditEvent v1. Producers
+must emit `occurredAt`; consumers should reject events that omit it or use
+`timestamp` instead.
+
+## Optional Fields
+
+- `causationId`: AuditEvent or protocol artifact id that directly caused this
+  event.
+- `sequence`: producer-assigned positive sequence number within the stream or
+  subject.
+- `severity`: `debug`, `info`, `notice`, `warning`, `error`, or `critical`.
+- `payload`: event-specific structured facts.
+- `dataClassification`: common v1 classification label.
+- `extensions`: `x-` prefixed extension map.
+
+Top-level fields outside the schema are rejected. Extension data must stay under
+`extensions` and must use `x-` prefixed keys so future core fields remain
+unambiguous.
+
+## Append-Only Usage
+
+AuditEvent streams are append-only. Producers should record new facts as new
+events instead of editing or replacing earlier events. Corrections should refer
+to the earlier event with `causationId` or a payload field that names the
+corrected event, while preserving the original event for evidence continuity.
+
+Consumers must not infer repository, tenant, account, authorization, or
+environment linkage from event ids, subject id shape, issue numbers, branch
+names, or operator-facing summaries. Those bindings must come from
+authoritative scope records outside this artifact. When the required binding,
+actor, subject, or provenance is missing or malformed, consumers should fail
+closed instead of accepting a guessed match.
+
+## Event Type Registry
+
+Event types use lowercase dot-separated namespaces. The first segment names the
+owning domain, later segments narrow the event family and action.
+
+| Event type | Owner | Meaning |
+| --- | --- | --- |
+| `loop.run.requested` | Ensen-loop | A loop run was requested. |
+| `flow.step.completed` | Ensen-flow | A flow step completed. |
+
+New event types should be added to this registry before producers emit them in
+published fixtures or compatibility tests.
+
+## Payload Safety
+
+`payload` is for bounded, structured, synthetic or production-safe event facts.
+It must not carry raw secrets, access tokens, private keys, passwords, customer
+private values, or host-local absolute paths. Store sensitive values in an
+approved secret store or evidence system and put only stable redacted references
+or public digests in the AuditEvent.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,8 @@ Start here:
 - `EIP-0000-common-types.md` defines common v1 schema types.
 - `EIP-0001-run-request.md` defines the RunRequest v1 executor request
   contract.
+- `EIP-0002-run-result.md` defines the RunResult v1 terminal result contract.
+- `EIP-0003-audit-event.md` defines the AuditEvent v1 append-only audit event
+  contract.
 - `data-classification.md` defines fixture and production data handling labels.
 - `idempotency.md` defines common correlation and retry conventions.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -12,3 +12,5 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
   safety examples.
 - `run-result/v1/valid/` contains valid EIP-0002 RunResult fixtures.
 - `run-result/v1/invalid/` contains negative RunResult fixtures.
+- `audit-event/v1/valid/` contains valid EIP-0003 AuditEvent fixtures.
+- `audit-event/v1/invalid/` contains negative AuditEvent fixtures.

--- a/fixtures/audit-event/v1/invalid/bad-event-type.json
+++ b/fixtures/audit-event/v1/invalid/bad-event-type.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "eip.audit-event.v1",
+  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9D",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "subject": {
+    "subjectId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    "subjectType": "run-request"
+  },
+  "type": "loop-run-requested",
+  "actor": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "service"
+  },
+  "occurredAt": "2026-04-29T03:20:00Z"
+}

--- a/fixtures/audit-event/v1/invalid/forbidden-timestamp.json
+++ b/fixtures/audit-event/v1/invalid/forbidden-timestamp.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": "eip.audit-event.v1",
+  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9E",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "subject": {
+    "subjectId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    "subjectType": "run-request"
+  },
+  "type": "loop.run.requested",
+  "actor": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "service"
+  },
+  "timestamp": "2026-04-29T03:20:00Z"
+}

--- a/fixtures/audit-event/v1/valid/flow-step-completed.json
+++ b/fixtures/audit-event/v1/valid/flow-step-completed.json
@@ -1,0 +1,25 @@
+{
+  "schemaVersion": "eip.audit-event.v1",
+  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9B",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "causationId": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9A",
+  "subject": {
+    "subjectId": "flowstep_01HVAX8J2K6T3QW4R5Y7M8N9C",
+    "subjectType": "flow-step",
+    "externalRef": "validation/audit-event-schema"
+  },
+  "type": "flow.step.completed",
+  "actor": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "service",
+    "displayName": "Ensen flow worker"
+  },
+  "occurredAt": "2026-04-29T03:25:00Z",
+  "sequence": 2,
+  "severity": "notice",
+  "payload": {
+    "stepName": "schema-validation",
+    "status": "completed"
+  },
+  "dataClassification": "public"
+}

--- a/fixtures/audit-event/v1/valid/loop-run-requested.json
+++ b/fixtures/audit-event/v1/valid/loop-run-requested.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": "eip.audit-event.v1",
+  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9A",
+  "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
+  "subject": {
+    "subjectId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    "subjectType": "run-request",
+    "externalRef": "github-issue-6"
+  },
+  "type": "loop.run.requested",
+  "actor": {
+    "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
+    "actorType": "service",
+    "displayName": "Ensen issue dispatcher"
+  },
+  "occurredAt": "2026-04-29T03:20:00Z",
+  "sequence": 1,
+  "severity": "info",
+  "payload": {
+    "mode": "plan",
+    "command": "npm test -- test/audit-event-schema.test.ts"
+  },
+  "dataClassification": "public",
+  "extensions": {
+    "x-fixture-note": "synthetic loop run requested event"
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -11,3 +11,5 @@ tests that demonstrate their intended interoperability behavior.
   contract for executor requests.
 - `eip.run-result.v1.schema.json` defines the transport-neutral RunResult v1
   contract for terminal executor results.
+- `eip.audit-event.v1.schema.json` defines the transport-neutral AuditEvent v1
+  contract for append-only audit and evidence streams.

--- a/schemas/eip.audit-event.v1.schema.json
+++ b/schemas/eip.audit-event.v1.schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.audit-event.v1.schema.json",
+  "title": "EIP-0003 AuditEvent v1",
+  "description": "Transport-neutral append-only audit and evidence stream event contract.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "subject",
+    "type",
+    "actor",
+    "occurredAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.audit-event.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "causationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "subject": {
+      "$ref": "#/$defs/AuditSubject"
+    },
+    "type": {
+      "$ref": "#/$defs/EventType"
+    },
+    "severity": {
+      "$ref": "#/$defs/AuditSeverity"
+    },
+    "actor": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ActorRef"
+    },
+    "occurredAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "payload": {
+      "$ref": "#/$defs/AuditPayload"
+    },
+    "dataClassification": {
+      "$ref": "eip.common.v1.schema.json#/$defs/DataClassification"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "AuditSubject": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["subjectId", "subjectType"],
+      "properties": {
+        "subjectId": {
+          "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+        },
+        "subjectType": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80,
+          "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+        },
+        "externalRef": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 240
+        }
+      }
+    },
+    "EventType": {
+      "type": "string",
+      "description": "Dot-separated event type namespace registered by the owning EIP.",
+      "minLength": 3,
+      "maxLength": 160,
+      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:\\.[a-z][a-z0-9]*(?:-[a-z0-9]+)*)+$"
+    },
+    "AuditSeverity": {
+      "type": "string",
+      "enum": ["debug", "info", "notice", "warning", "error", "critical"]
+    },
+    "AuditPayload": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/test/audit-event-schema.test.ts
+++ b/test/audit-event-schema.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas/eip.audit-event.v1.schema.json");
+const commonSchemaPath = path.join(repoRoot, "schemas/eip.common.v1.schema.json");
+const validFixturesDir = path.join(repoRoot, "fixtures/audit-event/v1/valid");
+const invalidFixturesDir = path.join(repoRoot, "fixtures/audit-event/v1/invalid");
+
+function readJson(relativeOrAbsolutePath: string): unknown {
+  const filePath = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(repoRoot, relativeOrAbsolutePath);
+
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+function readMarkdown(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fixturePaths(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(directory, entry))
+    .sort();
+}
+
+function auditEvent(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  const fixture = readJson("fixtures/audit-event/v1/valid/loop-run-requested.json");
+
+  return {
+    ...(fixture as Record<string, unknown>),
+    ...overrides,
+  };
+}
+
+describe("EIP-0003 AuditEvent schema", () => {
+  const schema = readJson(schemaPath);
+  const commonSchema = readJson(commonSchemaPath);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(commonSchema, "eip.common.v1.schema.json");
+  const validate = ajv.compile(schema);
+
+  it("requires the AuditEvent v1 append-only contract fields", () => {
+    expect(schema).toHaveProperty("required", [
+      "schemaVersion",
+      "id",
+      "correlationId",
+      "subject",
+      "type",
+      "actor",
+      "occurredAt",
+    ]);
+    expect(schema).toHaveProperty("properties.causationId");
+    expect(schema).toHaveProperty("properties.sequence");
+    expect(schema).toHaveProperty("properties.severity");
+    expect(schema).toHaveProperty("properties.payload");
+    expect(schema).toHaveProperty("properties.dataClassification");
+    expect(schema).toHaveProperty("properties.extensions");
+  });
+
+  it.each(fixturePaths(validFixturesDir))("accepts valid fixture %s", (fixturePath) => {
+    const fixture = readJson(fixturePath);
+
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(fixturePaths(invalidFixturesDir))(
+    "rejects invalid fixture %s",
+    (fixturePath) => {
+      const fixture = readJson(fixturePath);
+
+      expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(false);
+    }
+  );
+
+  it("requires occurredAt and rejects legacy timestamp", () => {
+    expect(validate(auditEvent({ occurredAt: undefined }))).toBe(false);
+    expect(validate(auditEvent({ timestamp: "2026-04-29T03:20:00Z" }))).toBe(false);
+  });
+
+  it("requires dot-separated event type namespaces", () => {
+    expect(validate(auditEvent({ type: "loop.run.requested" }))).toBe(true);
+    expect(validate(auditEvent({ type: "loop-run-requested" }))).toBe(false);
+  });
+});
+
+describe("EIP-0003 AuditEvent docs", () => {
+  it("documents append-only usage, event registry, and payload secret safety", () => {
+    const docs = readMarkdown("docs/EIP-0003-audit-event.md");
+
+    expect(docs).toContain("append-only");
+    expect(docs).toContain("Event Type Registry");
+    expect(docs).toContain("must not carry raw secrets");
+  });
+});


### PR DESCRIPTION
## Summary
- add AuditEvent v1 schema for append-only audit/evidence events
- add valid and invalid AuditEvent fixtures, including event type and timestamp rejection coverage
- add EIP-0003 docs and index entries

## Verification
- npm test -- test/audit-event-schema.test.ts
- npm test
- npm run check:spec-boundary

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced EIP-0003 AuditEvent v1 specification, defining a standardized audit event schema for recording audit and evidence trails across systems.

* **Documentation**
  * Added comprehensive EIP-0003 specification documentation with detailed requirements, append-only semantics, and extension guidelines.

* **Tests**
  * Added schema validation tests with valid and invalid fixture examples to ensure specification compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->