### PR TITLE
EIP-0004: Define EvidenceBundleRef v1 schema

### DIFF
--- a/docs/EIP-0004-evidence-bundle-ref.md
+++ b/docs/EIP-0004-evidence-bundle-ref.md
@@ -1,0 +1,63 @@
+# EIP-0004 EvidenceBundleRef v1
+
+EvidenceBundleRef v1 defines a transport-neutral reference to durable evidence
+material. The machine-readable schema lives in
+`schemas/eip.evidence-bundle-ref.v1.schema.json`.
+
+EvidenceBundleRef is a reference artifact, not the evidence bundle body. It must
+not embed logs, test output, screenshots, credentials, customer data, or other
+evidence payloads. Producers store the body in an evidence system or filesystem
+location and emit only the stable reference.
+
+## Required Fields
+
+- `schemaVersion`: must be `eip.evidence-bundle-ref.v1`.
+- `id`: the EvidenceBundleRef artifact id.
+- `correlationId`: shared tracing and retry correlation id.
+- `type`: the reference kind. v1 supports `local_path` and `file_uri`.
+- `uri`: the location of the evidence material using the syntax required by
+  `type`.
+- `createdAt`: UTC creation time for the reference artifact.
+
+## Reference Types
+
+`local_path` is for relative paths inside an agreed workspace, artifact root, or
+evidence root. The path must not be a host-local absolute path, URI, or parent
+directory traversal. Consumers resolve it only against the authoritative root
+configured for the producer or exchange boundary.
+
+`file_uri` is for explicit `file:///` URIs used when the exchange boundary has a
+documented filesystem namespace. It must not contain credentials, query strings,
+fragments, or parent directory traversal. Consumers must not infer tenant,
+repository, account, or authorization scope from the path shape.
+
+Other storage transports can be added in later schema versions after their
+credential and authorization boundaries are specified.
+
+## Optional Fields
+
+- `contentType`: media type of the referenced evidence body.
+- `checksum`: digest of the referenced body. v1 supports `sha256` with a
+  lowercase 64-character hexadecimal value.
+- `metadata`: small public descriptors about the reference.
+
+Top-level fields outside the schema are rejected. Metadata is not an extension
+point for evidence bodies or credentials.
+
+## Security
+
+EvidenceBundleRef must fail closed when provenance, scope, authorization
+context, or boundary signals are missing or malformed. A syntactically valid
+reference is not proof that the referenced material exists, is trusted, or is
+authorized for the current consumer.
+
+Reference URIs must not carry raw credentials or credential-shaped placeholders.
+When a producer needs authenticated storage, the credential belongs in the
+trusted storage boundary, not in the EvidenceBundleRef artifact.
+
+## Fixture Safety
+
+Checked-in EvidenceBundleRef fixtures must be synthetic and public. They should
+use repo-relative local paths or neutral `file:///` examples, never workstation
+home-directory paths, access tokens, passwords, private customer values, or
+evidence bundle bodies.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,7 @@ Start here:
 - `EIP-0002-run-result.md` defines the RunResult v1 terminal result contract.
 - `EIP-0003-audit-event.md` defines the AuditEvent v1 append-only audit event
   contract.
+- `EIP-0004-evidence-bundle-ref.md` defines the EvidenceBundleRef v1 evidence
+  reference contract.
 - `data-classification.md` defines fixture and production data handling labels.
 - `idempotency.md` defines common correlation and retry conventions.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -14,3 +14,7 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
 - `run-result/v1/invalid/` contains negative RunResult fixtures.
 - `audit-event/v1/valid/` contains valid EIP-0003 AuditEvent fixtures.
 - `audit-event/v1/invalid/` contains negative AuditEvent fixtures.
+- `evidence-bundle-ref/v1/valid/` contains valid EIP-0004 EvidenceBundleRef
+  fixtures.
+- `evidence-bundle-ref/v1/invalid/` contains negative EvidenceBundleRef
+  fixtures.

--- a/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
+++ b/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "local_path",
+  "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:15:00Z",
+  "checksum": {
+    "algorithm": "md5",
+    "value": "not-a-sha256-digest"
+  }
+}

--- a/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
+++ b/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "file_uri",
+  "uri": "https://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json",
+  "createdAt": "2026-04-29T00:10:00Z"
+}

--- a/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
+++ b/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
@@ -3,6 +3,6 @@
   "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "type": "file_uri",
-  "uri": "https://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json",
+  "uri": "file://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json",
   "createdAt": "2026-04-29T00:10:00Z"
 }

--- a/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
+++ b/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "file_uri",
+  "uri": "file:///var/lib/ensen/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:05:00Z",
+  "contentType": "application/json"
+}

--- a/fixtures/evidence-bundle-ref/v1/valid/local-path.json
+++ b/fixtures/evidence-bundle-ref/v1/valid/local-path.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "eip.evidence-bundle-ref.v1",
+  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "type": "local_path",
+  "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",
+  "createdAt": "2026-04-29T00:00:00Z",
+  "contentType": "application/json",
+  "checksum": {
+    "algorithm": "sha256",
+    "value": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "metadata": {
+    "producer": "ensen-loop",
+    "command": "npm test",
+    "redacted": true
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -13,3 +13,5 @@ tests that demonstrate their intended interoperability behavior.
   contract for terminal executor results.
 - `eip.audit-event.v1.schema.json` defines the transport-neutral AuditEvent v1
   contract for append-only audit and evidence streams.
+- `eip.evidence-bundle-ref.v1.schema.json` defines the transport-neutral
+  EvidenceBundleRef v1 contract for evidence material references.

--- a/schemas/eip.evidence-bundle-ref.v1.schema.json
+++ b/schemas/eip.evidence-bundle-ref.v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.evidence-bundle-ref.v1.schema.json",
+  "title": "EIP-0004 EvidenceBundleRef v1",
+  "description": "Transport-neutral reference to durable evidence material. This artifact identifies where evidence can be found; it does not embed the evidence body.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "correlationId",
+    "type",
+    "uri",
+    "createdAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.evidence-bundle-ref.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["local_path", "file_uri"]
+    },
+    "uri": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000,
+      "not": {
+        "pattern": "^[A-Za-z][A-Za-z0-9+.-]*://[^/?#\\s]*[^/?#\\s:@]+:[^/?#\\s:@]+@"
+      }
+    },
+    "createdAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "contentType": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 160,
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*/[A-Za-z0-9][A-Za-z0-9!#$&^_.+-]*(?:; ?[A-Za-z0-9_.-]+=[A-Za-z0-9_.+-]+)*$"
+    },
+    "checksum": {
+      "$ref": "#/$defs/Checksum"
+    },
+    "metadata": {
+      "$ref": "#/$defs/Metadata"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "local_path"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "pattern": "^(?![A-Za-z][A-Za-z0-9+.-]*://)(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))[A-Za-z0-9._~@/-]+$"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "file_uri"
+          }
+        },
+        "required": ["type"]
+      },
+      "then": {
+        "properties": {
+          "uri": {
+            "type": "string",
+            "pattern": "^file:///(?!.*(?:^|/)\\.\\.(?:/|$))[^\\s?#]+$"
+          }
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "Checksum": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["algorithm", "value"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "enum": ["sha256"]
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "Metadata": {
+      "type": "object",
+      "description": "Small public descriptors about the referenced evidence. Do not put evidence bodies or credentials here.",
+      "propertyNames": {
+        "pattern": "^[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*$"
+      },
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 500
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "null"
+          }
+        ]
+      },
+      "maxProperties": 20
+    }
+  }
+}

--- a/test/evidence-bundle-ref-schema.test.ts
+++ b/test/evidence-bundle-ref-schema.test.ts
@@ -1,0 +1,165 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas/eip.evidence-bundle-ref.v1.schema.json");
+const commonSchemaPath = path.join(repoRoot, "schemas/eip.common.v1.schema.json");
+const validFixturesDir = path.join(repoRoot, "fixtures/evidence-bundle-ref/v1/valid");
+const invalidFixturesDir = path.join(repoRoot, "fixtures/evidence-bundle-ref/v1/invalid");
+
+function readJson(relativeOrAbsolutePath: string): unknown {
+  const filePath = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(repoRoot, relativeOrAbsolutePath);
+
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+function readMarkdown(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fixturePaths(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(directory, entry))
+    .sort();
+}
+
+function evidenceBundleRef(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const fixture = readJson("fixtures/evidence-bundle-ref/v1/valid/local-path.json");
+
+  return {
+    ...(fixture as Record<string, unknown>),
+    ...overrides
+  };
+}
+
+function containsRawSecretUri(value: unknown): boolean {
+  if (typeof value === "string") {
+    return /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#\s]*[^/?#\s:@]+:[^/?#\s:@]+@/.test(
+      value
+    );
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => containsRawSecretUri(item));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some((nested) => containsRawSecretUri(nested));
+  }
+
+  return false;
+}
+
+describe("EIP-0004 EvidenceBundleRef schema", () => {
+  const schema = readJson(schemaPath);
+  const commonSchema = readJson(commonSchemaPath);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(commonSchema, "eip.common.v1.schema.json");
+  const validate = ajv.compile(schema);
+  const hostLocalPath = path.posix.join(
+    "/",
+    "Users",
+    "example",
+    "evidence",
+    "bundle.json"
+  );
+
+  it("requires the EvidenceBundleRef v1 contract fields", () => {
+    expect(schema).toHaveProperty("required", [
+      "schemaVersion",
+      "id",
+      "correlationId",
+      "type",
+      "uri",
+      "createdAt"
+    ]);
+    expect(schema).toHaveProperty("properties.contentType");
+    expect(schema).toHaveProperty("properties.checksum");
+    expect(schema).toHaveProperty("properties.metadata");
+  });
+
+  it.each(fixturePaths(validFixturesDir))("accepts valid fixture %s", (fixturePath) => {
+    const fixture = readJson(fixturePath);
+
+    expect(containsRawSecretUri(fixture)).toBe(false);
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(fixturePaths(invalidFixturesDir))(
+    "rejects invalid fixture %s",
+    (fixturePath) => {
+      const fixture = readJson(fixturePath);
+
+      expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(false);
+    }
+  );
+
+  it("supports only sha256 checksums initially", () => {
+    expect(
+      validate(
+        evidenceBundleRef({
+          checksum: {
+            algorithm: "sha256",
+            value: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+          }
+        })
+      ),
+      JSON.stringify(validate.errors, null, 2)
+    ).toBe(true);
+
+    expect(
+      validate(
+        evidenceBundleRef({
+          checksum: {
+            algorithm: "sha512",
+            value: "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+          }
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("rejects URI credentials and host-local absolute local paths", () => {
+    expect(
+      validate(
+        evidenceBundleRef({
+          type: "file_uri",
+          uri: "https://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json"
+        })
+      )
+    ).toBe(false);
+    expect(
+      containsRawSecretUri(
+        readJson("fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json")
+      )
+    ).toBe(true);
+
+    expect(
+      validate(
+        evidenceBundleRef({
+          type: "local_path",
+          uri: hostLocalPath
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("EIP-0004 EvidenceBundleRef docs", () => {
+  it("documents reference-only semantics and local path versus file URI usage", () => {
+    const docs = readMarkdown("docs/EIP-0004-evidence-bundle-ref.md");
+
+    expect(docs).toContain("not the evidence bundle body");
+    expect(docs).toContain("local_path");
+    expect(docs).toContain("file_uri");
+    expect(docs).toContain("must not contain credentials");
+  });
+});

--- a/test/evidence-bundle-ref-schema.test.ts
+++ b/test/evidence-bundle-ref-schema.test.ts
@@ -160,6 +160,8 @@ describe("EIP-0004 EvidenceBundleRef docs", () => {
     expect(docs).toContain("not the evidence bundle body");
     expect(docs).toContain("local_path");
     expect(docs).toContain("file_uri");
-    expect(docs).toContain("must not contain credentials");
+    expect(docs).toContain(
+      "must not carry raw credentials or credential-shaped placeholders"
+    );
   });
 });

--- a/test/evidence-bundle-ref-schema.test.ts
+++ b/test/evidence-bundle-ref-schema.test.ts
@@ -128,19 +128,20 @@ describe("EIP-0004 EvidenceBundleRef schema", () => {
   });
 
   it("rejects URI credentials and host-local absolute local paths", () => {
-    expect(
-      validate(
-        evidenceBundleRef({
-          type: "file_uri",
-          uri: "https://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json"
+    const rawSecretFixture = readJson(
+      "fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json"
+    );
+
+    expect(containsRawSecretUri(rawSecretFixture)).toBe(true);
+    expect(validate(rawSecretFixture)).toBe(false);
+    expect(validate.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          instancePath: "/uri",
+          keyword: "not"
         })
-      )
-    ).toBe(false);
-    expect(
-      containsRawSecretUri(
-        readJson("fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json")
-      )
-    ).toBe(true);
+      ])
+    );
 
     expect(
       validate(


### PR DESCRIPTION
## Summary
- add the standalone EvidenceBundleRef v1 schema
- add local_path and file_uri fixtures plus invalid raw-secret URI and checksum fixtures
- document reference-only semantics and local_path versus file_uri usage

## Verification
- npm test -- test/evidence-bundle-ref-schema.test.ts
- npm test
- npm run check:spec-boundary

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added EIP-0004 specification for EvidenceBundleRef v1 and updated docs/READMEs and schema index to reference it.
* **Schemas**
  * Introduced a JSON Schema for EvidenceBundleRef v1 enforcing required fields, URI/path constraints, checksum and metadata rules.
* **Fixtures**
  * Added valid and invalid example fixtures covering file URI, local path, checksum and secret/credential cases.
* **Tests**
  * Added tests validating the schema against fixtures and rejecting malformed or credential-containing references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->