### PR TITLE
Add RunStatusSnapshot v1 contract

### DIFF
--- a/docs/EIP-0005-run-status-snapshot.md
+++ b/docs/EIP-0005-run-status-snapshot.md
@@ -1,0 +1,90 @@
+# EIP-0005 RunStatusSnapshot v1
+
+RunStatusSnapshot v1 defines the transport-neutral polling artifact an
+Ensen-compatible async executor may expose while a run is accepted, queued,
+running, cancelling, or recently terminal. The machine-readable schema lives in
+`schemas/eip.run-status.v1.schema.json`.
+
+RunStatusSnapshot is a contract document, not a runtime service, workflow
+engine, connector implementation, queue implementation, or replacement for
+RunResult.
+
+## Required Fields
+
+- `schemaVersion`: must be `eip.run-status.v1`.
+- `id`: the RunStatusSnapshot artifact id.
+- `requestId`: the RunRequest artifact id this snapshot describes.
+- `correlationId`: shared tracing and retry correlation id.
+- `status`: current observed run status.
+- `observedAt`: UTC time when this snapshot was observed.
+
+## Statuses
+
+- `accepted`: the executor boundary accepted the request but has not queued
+  work yet.
+- `queued`: work is waiting for executor capacity.
+- `running`: work is actively executing.
+- `cancelling`: cancellation was requested and is still being applied.
+- `cancelled`: the run was stopped before normal completion.
+- `completed`: the run reached normal completion.
+- `failed`: the run attempted work and failed.
+- `blocked`: the run cannot continue because a prerequisite is missing.
+- `unknown`: the executor cannot currently determine the run state.
+
+Consumers must treat `unknown` as non-authoritative. They should retry, fall
+back to the authoritative executor record, or escalate instead of inferring a
+successful result.
+
+## Optional Fields
+
+- `runId`: executor-local run id when the executor has assigned one.
+- `message`: bounded operator-facing status text.
+- `progress`: bounded progress counters such as `current`, `total`, `percent`,
+  and `unit`.
+- `extensions`: `x-` prefixed extension map.
+
+Top-level fields outside the schema are rejected. Extension data must stay under
+`extensions` and must use `x-` prefixed keys so future core fields remain
+unambiguous.
+
+## RunResult Separation
+
+RunStatusSnapshot is for polling state. It must not carry final-result-only
+details such as `completedAt`, `changeRequests`, `evidenceBundles`,
+`verification`, terminal `errors`, terminal `warnings`, or terminal `metrics`.
+
+When a snapshot reports `completed`, `failed`, `blocked`, or `cancelled`, it is
+only a status echo. Consumers retrieve final details via RunResult. RunResult is
+the terminal artifact that carries completion time, evidence references, change
+request references, verification summaries, diagnostics, and metrics.
+
+## Connector Use
+
+An Ensen-flow executor connector may use RunStatusSnapshot as the shared polling
+contract for an asynchronous executor:
+
+1. Ensen-flow submits or receives a RunRequest.
+2. The executor connector polls the executor-specific boundary.
+3. The connector normalizes each observation into RunStatusSnapshot v1.
+4. Ensen-flow displays or routes the snapshot while continuing to wait for the
+   terminal RunResult.
+
+This lets an Ensen-flow executor connector interoperate with async executors
+without importing Ensen-loop runtime code, queue internals, or loop-specific
+state machines. The connector only depends on the protocol artifact shape.
+
+## Binding and Safety
+
+`requestId` is the explicit binding to the RunRequest this snapshot describes.
+Consumers must not infer repository, tenant, account, authorization, or
+environment linkage from id shape, branch names, issue numbers, status text, or
+nearby operator-facing metadata. Those bindings must come from authoritative
+scope records outside this artifact.
+
+When `requestId`, `correlationId`, provenance, or scope context is missing or
+malformed, consumers should fail closed instead of accepting a guessed match.
+
+Checked-in RunStatusSnapshot fixtures must be synthetic and public. Raw
+credentials, access tokens, private customer values, and host-local absolute
+paths are not valid fixture content, even inside `extensions`, `message`, or
+progress text.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,5 +21,7 @@ Start here:
   contract.
 - `EIP-0004-evidence-bundle-ref.md` defines the EvidenceBundleRef v1 evidence
   reference contract.
+- `EIP-0005-run-status-snapshot.md` defines the RunStatusSnapshot v1 async
+  executor polling contract.
 - `data-classification.md` defines fixture and production data handling labels.
 - `idempotency.md` defines common correlation and retry conventions.

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -18,3 +18,5 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
   fixtures.
 - `evidence-bundle-ref/v1/invalid/` contains negative EvidenceBundleRef
   fixtures.
+- `run-status/v1/valid/` contains valid EIP-0005 RunStatusSnapshot fixtures.
+- `run-status/v1/invalid/` contains negative RunStatusSnapshot fixtures.

--- a/fixtures/run-status/v1/invalid/final-result-only-fields.json
+++ b/fixtures/run-status/v1/invalid/final-result-only-fields.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "status": "completed",
+  "observedAt": "2026-04-29T00:05:00Z",
+  "completedAt": "2026-04-29T00:05:00Z",
+  "changeRequests": [
+    {
+      "changeRequestId": "pr_01HV9ZX8J2K6T3QW4R5Y7M8N9X"
+    }
+  ]
+}

--- a/fixtures/run-status/v1/valid/accepted-snapshot.json
+++ b/fixtures/run-status/v1/valid/accepted-snapshot.json
@@ -1,0 +1,9 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "status": "accepted",
+  "observedAt": "2026-04-29T00:00:00Z",
+  "message": "Run request accepted by the executor boundary."
+}

--- a/fixtures/run-status/v1/valid/completed-snapshot.json
+++ b/fixtures/run-status/v1/valid/completed-snapshot.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "runId": "executor-run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "status": "completed",
+  "observedAt": "2026-04-29T00:05:00Z",
+  "message": "Run completed. Retrieve final details from RunResult."
+}

--- a/fixtures/run-status/v1/valid/running-snapshot.json
+++ b/fixtures/run-status/v1/valid/running-snapshot.json
@@ -1,0 +1,16 @@
+{
+  "schemaVersion": "eip.run-status.v1",
+  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+  "runId": "executor-run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "status": "running",
+  "observedAt": "2026-04-29T00:01:00Z",
+  "message": "Executor is running validation.",
+  "progress": {
+    "current": 2,
+    "total": 5,
+    "percent": 40,
+    "unit": "steps"
+  }
+}

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -15,3 +15,5 @@ tests that demonstrate their intended interoperability behavior.
   contract for append-only audit and evidence streams.
 - `eip.evidence-bundle-ref.v1.schema.json` defines the transport-neutral
   EvidenceBundleRef v1 contract for evidence material references.
+- `eip.run-status.v1.schema.json` defines the transport-neutral
+  RunStatusSnapshot v1 contract for async executor status polling.

--- a/schemas/eip.run-status.v1.schema.json
+++ b/schemas/eip.run-status.v1.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eip.ensen.dev/schemas/eip.run-status.v1.schema.json",
+  "title": "EIP-0005 RunStatusSnapshot v1",
+  "description": "Transport-neutral polling snapshot contract for Ensen-compatible async executor runs.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schemaVersion",
+    "id",
+    "requestId",
+    "correlationId",
+    "status",
+    "observedAt"
+  ],
+  "properties": {
+    "schemaVersion": {
+      "const": "eip.run-status.v1"
+    },
+    "id": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "requestId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "correlationId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/CorrelationId"
+    },
+    "runId": {
+      "$ref": "eip.common.v1.schema.json#/$defs/PrefixedId"
+    },
+    "status": {
+      "$ref": "#/$defs/RunStatus"
+    },
+    "observedAt": {
+      "$ref": "eip.common.v1.schema.json#/$defs/IsoDateTimeUtc"
+    },
+    "message": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 1000
+    },
+    "progress": {
+      "$ref": "#/$defs/RunProgress"
+    },
+    "extensions": {
+      "$ref": "eip.common.v1.schema.json#/$defs/ExtensionMap"
+    }
+  },
+  "$defs": {
+    "RunStatus": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "queued",
+        "running",
+        "cancelling",
+        "cancelled",
+        "completed",
+        "failed",
+        "blocked",
+        "unknown"
+      ]
+    },
+    "RunProgress": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "properties": {
+        "current": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "percent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "unit": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 80
+        }
+      }
+    }
+  }
+}

--- a/test/run-status-schema.test.ts
+++ b/test/run-status-schema.test.ts
@@ -1,0 +1,136 @@
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const schemaPath = path.join(repoRoot, "schemas/eip.run-status.v1.schema.json");
+const commonSchemaPath = path.join(repoRoot, "schemas/eip.common.v1.schema.json");
+const validFixturesDir = path.join(repoRoot, "fixtures/run-status/v1/valid");
+const invalidFixturesDir = path.join(repoRoot, "fixtures/run-status/v1/invalid");
+
+function readJson(relativeOrAbsolutePath: string): unknown {
+  const filePath = path.isAbsolute(relativeOrAbsolutePath)
+    ? relativeOrAbsolutePath
+    : path.join(repoRoot, relativeOrAbsolutePath);
+
+  return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+}
+
+function readMarkdown(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function fixturePaths(directory: string): string[] {
+  return readdirSync(directory)
+    .filter((entry) => entry.endsWith(".json"))
+    .map((entry) => path.join(directory, entry))
+    .sort();
+}
+
+describe("EIP-0005 RunStatusSnapshot schema", () => {
+  const schema = readJson(schemaPath);
+  const commonSchema = readJson(commonSchemaPath);
+  const ajv = new Ajv2020({ allErrors: true, strict: true });
+  ajv.addSchema(commonSchema, "eip.common.v1.schema.json");
+  const validate = ajv.compile(schema);
+
+  function runStatusSnapshot(
+    overrides: Record<string, unknown> = {}
+  ): Record<string, unknown> {
+    return {
+      schemaVersion: "eip.run-status.v1",
+      id: "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+      requestId: "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      status: "running",
+      observedAt: "2026-04-29T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("requires the RunStatusSnapshot v1 polling contract fields", () => {
+    expect(schema).toHaveProperty("required", [
+      "schemaVersion",
+      "id",
+      "requestId",
+      "correlationId",
+      "status",
+      "observedAt",
+    ]);
+  });
+
+  it.each(fixturePaths(validFixturesDir))("accepts valid fixture %s", (fixturePath) => {
+    const fixture = readJson(fixturePath);
+
+    expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(true);
+  });
+
+  it.each(fixturePaths(invalidFixturesDir))(
+    "rejects invalid fixture %s",
+    (fixturePath) => {
+      const fixture = readJson(fixturePath);
+
+      expect(validate(fixture), JSON.stringify(validate.errors, null, 2)).toBe(false);
+    }
+  );
+
+  it("accepts polling statuses including terminal status echoes", () => {
+    for (const status of [
+      "accepted",
+      "queued",
+      "running",
+      "cancelling",
+      "cancelled",
+      "completed",
+      "failed",
+      "blocked",
+      "unknown",
+    ]) {
+      expect(
+        validate(runStatusSnapshot({ status })),
+        JSON.stringify(validate.errors, null, 2)
+      ).toBe(true);
+    }
+  });
+
+  it("supports optional runId, message, and progress", () => {
+    expect(
+      validate(
+        runStatusSnapshot({
+          runId: "executor-run_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+          message: "Executor is running verification.",
+          progress: {
+            current: 2,
+            total: 5,
+            unit: "steps",
+          },
+        })
+      ),
+      JSON.stringify(validate.errors, null, 2)
+    ).toBe(true);
+  });
+
+  it("rejects final-result-only fields", () => {
+    expect(
+      validate(
+        runStatusSnapshot({
+          completedAt: "2026-04-29T00:05:00Z",
+          changeRequests: [{ changeRequestId: "pr_01HV9ZX8J2K6T3QW4R5Y7M8N9U" }],
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe("EIP-0005 RunStatusSnapshot docs", () => {
+  it("documents RunResult separation and Ensen-flow executor connector use", () => {
+    const docs = readMarkdown("docs/EIP-0005-run-status-snapshot.md");
+
+    expect(docs).toContain("RunResult");
+    expect(docs).toContain("final details");
+    expect(docs).toContain("Ensen-flow executor connector");
+    expect(docs).toContain("without importing Ensen-loop");
+  });
+});


### PR DESCRIPTION
## Summary
- add EIP-0005 RunStatusSnapshot v1 schema for async executor polling
- add accepted, running, and completed valid fixtures plus a final-result-only invalid fixture
- document RunResult separation and Ensen-flow executor connector usage without importing Ensen-loop

## Verification
- npm test -- test/run-status-schema.test.ts
- npm test
- npm run check:spec-boundary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added EIP-0005 specification defining the RunStatusSnapshot v1 contract for async executor status polling, including required and optional fields with validation rules.
  * Updated documentation indices to reference the new specification.

* **Tests**
  * Added comprehensive schema validation tests with fixtures demonstrating valid and invalid payload examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->