### PR TITLE
Add EIP-0007 integration handoff notes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,12 @@ Start here:
 - `versioning.md` defines versioning expectations.
 - `compatibility.md` defines compatibility and deprecation rules.
 - `conformance.md` defines fixture validation and vendoring guidance.
+- `integration/ensen-loop-consumer-guide.md` defines loop-side protocol
+  consumption and fixture handoff guidance.
+- `integration/ensen-flow-consumer-guide.md` defines flow-side protocol
+  consumption and fixture handoff guidance.
+- `integration/cross-repo-change-policy.md` defines the protocol-first
+  cross-repo change process.
 - `security.md` defines security posture for protocol artifacts.
 - `EIP-0000-common-types.md` defines common v1 schema types.
 - `EIP-0001-run-request.md` defines the RunRequest v1 executor request

--- a/docs/integration/cross-repo-change-policy.md
+++ b/docs/integration/cross-repo-change-policy.md
@@ -1,0 +1,63 @@
+# Cross-Repo Change Policy
+
+Protocol changes start in Ensen-protocol. Runtime repositories consume the
+accepted contract after the protocol issue defines the schema, fixture, and
+compatibility impact.
+
+## Protocol-First Flow
+
+1. Open the protocol issue first in Ensen-protocol.
+2. Define the affected EIP text, schema, fixture, compatibility, and security
+   expectations in the protocol issue or linked pull request.
+3. Land protocol artifacts before depending on them from Ensen-loop or
+   Ensen-flow.
+4. Open follow-up Ensen-loop or Ensen-flow issues that reference the protocol
+   issue and the protocol commit or release.
+5. Vendor or copy the accepted fixture snapshots into each runtime repository's
+   conformance tests.
+6. Keep runtime-local implementation examples in the runtime repository, not in
+   Ensen-protocol.
+
+The protocol issue first rule prevents runtime behavior from becoming the
+undocumented source of truth.
+
+## Dependency Boundary
+
+Ensen-loop and Ensen-flow must not import each other's implementation code,
+private helpers, service modules, connector code, or runtime tests. They may both
+consume the same protocol docs, schemas, and public fixture snapshots.
+
+This repository must not add runtime implementation directories such as
+`src/runtime`, `src/workflow`, `src/loop`, or `src/connectors`.
+
+## Fixture Snapshot Policy
+
+Runtime repositories should vendor or copy fixture snapshots rather than import
+runtime code from another repository. A runtime-side vendoring record should
+include:
+
+- the source Ensen-protocol commit or release;
+- the copied schema and fixture relative paths;
+- the local conformance test that consumes the snapshot;
+- any unsupported optional fields and the planned follow-up issue.
+
+Invalid fixtures remain useful. Copy them as fail-closed regression tests when
+the runtime parser or adapter boundary should reject the same input.
+
+## Support Matrix Example
+
+| Artifact | Protocol owner | Ensen-loop issue | Ensen-flow issue | Fixture handoff |
+| --- | --- | --- | --- | --- |
+| RunRequest v1 field addition | Ensen-protocol issue first | Open after protocol acceptance if loop dispatch changes | Open after protocol acceptance if flow request authoring changes | Copy updated `fixtures/run-request/v1/` snapshot |
+| RunResult v1 terminal status change | Ensen-protocol issue first | Open if loop result publication changes | Open if flow result consumption changes | Copy updated `fixtures/run-result/v1/` snapshot |
+| EvidenceBundleRef v1 URI rule | Ensen-protocol issue first | Open if loop evidence references change | Open if flow evidence display or export changes | Copy updated `fixtures/evidence-bundle-ref/v1/` snapshot |
+
+## Release Notes
+
+Protocol pull requests that affect runtime consumers should include:
+
+- the protocol issue link;
+- the affected EIP artifacts;
+- the fixture snapshot paths to copy;
+- expected Ensen-loop and Ensen-flow follow-up issue links, or a note that no
+  runtime follow-up is required.

--- a/docs/integration/ensen-flow-consumer-guide.md
+++ b/docs/integration/ensen-flow-consumer-guide.md
@@ -1,0 +1,41 @@
+# Ensen-flow Consumer Guide
+
+Ensen-flow consumes Ensen protocol artifacts as published contracts. It should
+read schemas, examples, compatibility notes, and conformance fixtures from this
+repository without sharing runtime dependencies with Ensen-loop.
+
+Ensen-flow must not import Ensen-loop implementation code, loop services,
+connector modules, or private test helpers. Ensen-loop must likewise remain an
+independent consumer of the same protocol artifacts.
+
+## Fixture Handoff
+
+Use copied or vendored fixture snapshots for flow-side conformance tests:
+
+- copy the required `schemas/` files and matching
+  `fixtures/<artifact>/v<version>/` directories into the Ensen-flow test tree;
+- preserve the upstream relative path and fixture file name in local metadata;
+- record the Ensen-protocol commit used for the snapshot;
+- treat `valid/` fixtures as required compatibility examples;
+- treat `invalid/` fixtures as fail-closed regression coverage;
+- keep flow-specific credentials, tenant ids, host names, and operator paths out
+  of the vendored snapshot.
+
+Do not import Ensen-loop runtime code to build flow fixtures. If flow-specific
+examples are needed, add them in the Ensen-flow repository as local examples and
+label them separately from protocol conformance fixtures.
+
+## Support Matrix Example
+
+| Artifact | Protocol source | Flow usage | Handoff expectation |
+| --- | --- | --- | --- |
+| RunRequest v1 | `schemas/eip.run-request.v1.schema.json` and `fixtures/run-request/v1/` | Validate flow-authored executor requests | Copy schema and fixtures into flow conformance tests |
+| RunResult v1 | `schemas/eip.run-result.v1.schema.json` and `fixtures/run-result/v1/` | Validate consumed terminal executor outcomes | Copy schema and fixtures; keep flow-local result examples separate |
+| EvidenceBundleRef v1 | `schemas/eip.evidence-bundle-ref.v1.schema.json` and `fixtures/evidence-bundle-ref/v1/` | Validate evidence references surfaced in flow state | Copy schema and fixtures; use placeholders for local evidence roots |
+| AuditEvent v1 | `schemas/eip.audit-event.v1.schema.json` and `fixtures/audit-event/v1/` | Validate flow-originated audit events | Copy schema and fixtures; add flow-only audit samples locally if needed |
+
+## Change Intake
+
+When Ensen-flow needs a contract change, open or reference the Ensen-protocol
+issue first. Implement flow changes only after the protocol change is accepted,
+documented, and backed by schema or fixture updates where applicable.

--- a/docs/integration/ensen-loop-consumer-guide.md
+++ b/docs/integration/ensen-loop-consumer-guide.md
@@ -1,0 +1,41 @@
+# Ensen-loop Consumer Guide
+
+Ensen-loop consumes Ensen protocol artifacts as published contracts. It should
+read schemas, examples, compatibility notes, and conformance fixtures from this
+repository without sharing runtime dependencies with Ensen-flow.
+
+Ensen-loop must not import Ensen-flow implementation code, adapters, workflow
+modules, or private test helpers. Ensen-flow must likewise remain an independent
+consumer of the same protocol artifacts.
+
+## Fixture Handoff
+
+Use copied or vendored fixture snapshots for loop-side conformance tests:
+
+- copy the required `schemas/` files and matching
+  `fixtures/<artifact>/v<version>/` directories into the Ensen-loop test tree;
+- preserve the upstream relative path and fixture file name in local metadata;
+- record the Ensen-protocol commit used for the snapshot;
+- treat `valid/` fixtures as required compatibility examples;
+- treat `invalid/` fixtures as fail-closed regression coverage;
+- keep loop-specific credentials, tenant ids, host names, and operator paths out
+  of the vendored snapshot.
+
+Do not import Ensen-flow runtime code to build loop fixtures. If loop-specific
+examples are needed, add them in the Ensen-loop repository as local examples and
+label them separately from protocol conformance fixtures.
+
+## Support Matrix Example
+
+| Artifact | Protocol source | Loop usage | Handoff expectation |
+| --- | --- | --- | --- |
+| RunRequest v1 | `schemas/eip.run-request.v1.schema.json` and `fixtures/run-request/v1/` | Validate accepted run inputs before executor dispatch | Copy schema and fixtures into loop conformance tests |
+| RunResult v1 | `schemas/eip.run-result.v1.schema.json` and `fixtures/run-result/v1/` | Validate terminal executor outcomes | Copy schema and fixtures; keep loop-local result examples separate |
+| RunStatusSnapshot v1 | `schemas/eip.run-status.v1.schema.json` and `fixtures/run-status/v1/` | Validate async status polling output | Copy schema and fixtures; document unsupported optional fields |
+| AuditEvent v1 | `schemas/eip.audit-event.v1.schema.json` and `fixtures/audit-event/v1/` | Validate emitted loop audit events | Copy schema and fixtures; add loop-only audit samples locally if needed |
+
+## Change Intake
+
+When Ensen-loop needs a contract change, open or reference the Ensen-protocol
+issue first. Implement loop changes only after the protocol change is accepted,
+documented, and backed by schema or fixture updates where applicable.

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const workstationHomePathFragments = [
   ["/", "Users", "/"].join(""),
+  ["/", "home", "/"].join(""),
   ["C:", "\\", "Users", "\\"].join("")
 ];
 
@@ -20,6 +21,12 @@ function hasWorkstationHomePath(content: string): boolean {
 }
 
 describe("integration handoff documentation", () => {
+  it("detects common workstation home path fragments", () => {
+    expect(
+      hasWorkstationHomePath(["/", "home", "/", "operator", "/", "repo"].join(""))
+    ).toBe(true);
+  });
+
   it("documents loop and flow as independent protocol consumers", () => {
     const loopGuide = readDoc("docs/integration/ensen-loop-consumer-guide.md");
     const flowGuide = readDoc("docs/integration/ensen-flow-consumer-guide.md");

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workstationHomePathFragments = [
+  ["/", "Users", "/"].join(""),
+  ["C:", "\\", "Users", "\\"].join("")
+];
+
+function readDoc(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function hasWorkstationHomePath(content: string): boolean {
+  return workstationHomePathFragments.some((fragment) =>
+    content.includes(fragment)
+  );
+}
+
+describe("integration handoff documentation", () => {
+  it("documents loop and flow as independent protocol consumers", () => {
+    const loopGuide = readDoc("docs/integration/ensen-loop-consumer-guide.md");
+    const flowGuide = readDoc("docs/integration/ensen-flow-consumer-guide.md");
+
+    for (const guide of [loopGuide, flowGuide]) {
+      expect(guide).toMatch(/must not import .*implementation/i);
+      expect(guide).toMatch(/vendor|copy/i);
+      expect(guide).toMatch(/fixtures?/i);
+      expect(guide).toContain("| Artifact |");
+      expect(hasWorkstationHomePath(guide)).toBe(false);
+    }
+  });
+
+  it("defines protocol-first cross-repo change flow", () => {
+    const policy = readDoc("docs/integration/cross-repo-change-policy.md");
+
+    expect(policy).toMatch(/protocol issue first/i);
+    expect(policy).toMatch(/Ensen-loop/i);
+    expect(policy).toMatch(/Ensen-flow/i);
+    expect(policy).toMatch(/must not import .*implementation/i);
+    expect(hasWorkstationHomePath(policy)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add Ensen-loop and Ensen-flow protocol consumer guides
- add cross-repo protocol-first change policy with fixture snapshot guidance
- add focused docs regression coverage for the handoff requirements

## Verification
- npm test -- test/integration-docs.test.ts
- npm test
- npm run check:spec-boundary

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added integration guides for Ensen-loop and Ensen-flow consumers detailing fixture handoff, dependency boundaries, and protocol-first change intake.
  * Introduced a cross-repository change policy describing how protocol changes must be defined and coordinated before runtime adoption.
  * Updated main documentation navigation with new "Start here" entries for these topics.

* **Tests**
  * Added integration tests that validate the new documentation against protocol-first handoff rules and forbidden path fragments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->