### PR TITLE
Fix ActorRef actor type enum

### DIFF
--- a/docs/EIP-0000-common-types.md
+++ b/docs/EIP-0000-common-types.md
@@ -43,7 +43,9 @@ records.
 ## Common Reference Types
 
 ActorRef identifies the actor associated with an artifact. It requires an
-explicit actorId and actorType.
+explicit actorId and actorType. Actor type values are limited to the Phase 1
+actor categories: `human`, `workflow`, `system`, `api_client`, `connector`,
+`executor`, and `agent`.
 
 SourceRef identifies the source system or fixture family that produced the
 artifact. It requires an explicit sourceId and sourceType.

--- a/fixtures/audit-event/v1/invalid/bad-event-type.json
+++ b/fixtures/audit-event/v1/invalid/bad-event-type.json
@@ -9,7 +9,7 @@
   "type": "loop-run-requested",
   "actor": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
-    "actorType": "service"
+    "actorType": "connector"
   },
   "occurredAt": "2026-04-29T03:20:00Z"
 }

--- a/fixtures/audit-event/v1/invalid/forbidden-timestamp.json
+++ b/fixtures/audit-event/v1/invalid/forbidden-timestamp.json
@@ -9,7 +9,7 @@
   "type": "loop.run.requested",
   "actor": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
-    "actorType": "service"
+    "actorType": "connector"
   },
   "timestamp": "2026-04-29T03:20:00Z"
 }

--- a/fixtures/audit-event/v1/valid/flow-step-completed.json
+++ b/fixtures/audit-event/v1/valid/flow-step-completed.json
@@ -11,7 +11,7 @@
   "type": "flow.step.completed",
   "actor": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
-    "actorType": "service",
+    "actorType": "executor",
     "displayName": "Ensen flow worker"
   },
   "occurredAt": "2026-04-29T03:25:00Z",

--- a/fixtures/audit-event/v1/valid/loop-run-requested.json
+++ b/fixtures/audit-event/v1/valid/loop-run-requested.json
@@ -10,7 +10,7 @@
   "type": "loop.run.requested",
   "actor": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
-    "actorType": "service",
+    "actorType": "connector",
     "displayName": "Ensen issue dispatcher"
   },
   "occurredAt": "2026-04-29T03:20:00Z",

--- a/fixtures/common/v1/invalid/bad-actor-type.json
+++ b/fixtures/common/v1/invalid/bad-actor-type.json
@@ -3,7 +3,8 @@
   "correlationId": "corr_commonTypes0001",
   "createdAt": "2026-04-29T01:00:00Z",
   "actor": {
-    "actorType": "workflow"
+    "actorId": "actor_service0001",
+    "actorType": "service"
   },
   "source": {
     "sourceId": "source_fixture0001",

--- a/fixtures/common/v1/invalid/bad-classification.json
+++ b/fixtures/common/v1/invalid/bad-classification.json
@@ -3,8 +3,8 @@
   "correlationId": "corr_commonTypes0001",
   "createdAt": "2026-04-29T01:00:00Z",
   "actor": {
-    "actorId": "actor_service0001",
-    "actorType": "service"
+    "actorId": "actor_workflow001",
+    "actorType": "workflow"
   },
   "source": {
     "sourceId": "source_fixture0001",

--- a/fixtures/common/v1/invalid/bad-extension-key.json
+++ b/fixtures/common/v1/invalid/bad-extension-key.json
@@ -3,8 +3,8 @@
   "correlationId": "corr_commonTypes0001",
   "createdAt": "2026-04-29T01:00:00Z",
   "actor": {
-    "actorId": "actor_service0001",
-    "actorType": "service"
+    "actorId": "actor_workflow001",
+    "actorType": "workflow"
   },
   "source": {
     "sourceId": "source_fixture0001",

--- a/fixtures/common/v1/invalid/bad-timestamp.json
+++ b/fixtures/common/v1/invalid/bad-timestamp.json
@@ -3,8 +3,8 @@
   "correlationId": "corr_commonTypes0001",
   "createdAt": "2026-04-29T01:00:00+09:00",
   "actor": {
-    "actorId": "actor_service0001",
-    "actorType": "service"
+    "actorId": "actor_workflow001",
+    "actorType": "workflow"
   },
   "source": {
     "sourceId": "source_fixture0001",

--- a/fixtures/common/v1/valid/agent-actor-envelope.json
+++ b/fixtures/common/v1/valid/agent-actor-envelope.json
@@ -1,0 +1,28 @@
+{
+  "artifactId": "artifact_agentActor001",
+  "correlationId": "corr_agentActor0001",
+  "createdAt": "2026-04-29T01:00:00Z",
+  "actor": {
+    "actorId": "actor_agent0001",
+    "actorType": "agent",
+    "displayName": "Fixture Agent"
+  },
+  "source": {
+    "sourceId": "source_fixture0001",
+    "sourceType": "fixture",
+    "externalRef": "public-fixture/agent-actor-envelope"
+  },
+  "workItem": {
+    "workItemId": "work-item_protocol0001",
+    "title": "Define common schema conventions"
+  },
+  "changeRequest": {
+    "changeRequestId": "change-request_issue0003",
+    "status": "open"
+  },
+  "evidenceBundle": {
+    "evidenceBundleId": "evidence-bundle_common0001",
+    "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  },
+  "classification": "public"
+}

--- a/fixtures/common/v1/valid/common-envelope.json
+++ b/fixtures/common/v1/valid/common-envelope.json
@@ -3,8 +3,8 @@
   "correlationId": "corr_commonTypes0001",
   "createdAt": "2026-04-29T01:00:00Z",
   "actor": {
-    "actorId": "actor_service0001",
-    "actorType": "service",
+    "actorId": "actor_workflow001",
+    "actorType": "workflow",
     "displayName": "Fixture Producer"
   },
   "source": {

--- a/fixtures/run-request/v1/invalid/bad-schema-version.json
+++ b/fixtures/run-request/v1/invalid/bad-schema-version.json
@@ -9,7 +9,7 @@
   },
   "requestedBy": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2CD",
-    "actorType": "service"
+    "actorType": "api_client"
   },
   "workItem": {
     "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2CE",

--- a/fixtures/run-request/v1/invalid/source-string.json
+++ b/fixtures/run-request/v1/invalid/source-string.json
@@ -6,7 +6,7 @@
   "source": "github",
   "requestedBy": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2EC",
-    "actorType": "service"
+    "actorType": "api_client"
   },
   "workItem": {
     "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2ED",

--- a/fixtures/run-request/v1/invalid/unknown-top-level-field.json
+++ b/fixtures/run-request/v1/invalid/unknown-top-level-field.json
@@ -9,7 +9,7 @@
   },
   "requestedBy": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2FD",
-    "actorType": "service"
+    "actorType": "api_client"
   },
   "workItem": {
     "workItemId": "workitem_01HV7Y8M8F2KQ5W3P9R6T4N2FE",

--- a/fixtures/run-request/v1/valid/github-issue-request.json
+++ b/fixtures/run-request/v1/valid/github-issue-request.json
@@ -10,7 +10,7 @@
   },
   "requestedBy": {
     "actorId": "actor_01HV7Y8M8F2KQ5W3P9R6T4N2AE",
-    "actorType": "service",
+    "actorType": "api_client",
     "displayName": "Ensen issue dispatcher"
   },
   "workItem": {

--- a/schemas/eip.common.v1.schema.json
+++ b/schemas/eip.common.v1.schema.json
@@ -77,7 +77,7 @@
         },
         "actorType": {
           "type": "string",
-          "enum": ["human", "service", "system"]
+          "enum": ["human", "workflow", "system", "api_client", "connector", "executor", "agent"]
         },
         "displayName": {
           "type": "string",

--- a/scripts/validate-fixtures.ts
+++ b/scripts/validate-fixtures.ts
@@ -22,6 +22,7 @@ const fixtureSuites = [
     fixtureRoot: "common/v1",
     schemaPath: "schemas/eip.common.v1.schema.json",
     invalidReasons: new Map([
+      ["bad-actor-type.json", "allowed values"],
       ["bad-classification.json", "allowed values"],
       ["bad-extension-key.json", "property name"],
       ["bad-timestamp.json", "pattern"],

--- a/test/common-schema.test.ts
+++ b/test/common-schema.test.ts
@@ -89,6 +89,39 @@ describe("EIP-0000 common schema", () => {
     }
   );
 
+  it.each(["human", "workflow", "system", "api_client", "connector", "executor", "agent"])(
+    "accepts design-listed ActorRef actorType: %s",
+    (actorType) => {
+      expect(
+        validate(
+          commonEnvelope({
+            actor: {
+              actorId: "actor_01HV9ZX8J2K6T3QW4R5Y7M8N9A",
+              actorType,
+            },
+          })
+        ),
+        JSON.stringify(validate.errors, null, 2)
+      ).toBe(true);
+    }
+  );
+
+  it.each(["service", "workflow-engine", "apiClient", ""])(
+    "rejects malformed or non-design ActorRef actorType: %s",
+    (actorType) => {
+      expect(
+        validate(
+          commonEnvelope({
+            actor: {
+              actorId: "actor_01HV9ZX8J2K6T3QW4R5Y7M8N9A",
+              actorType,
+            },
+          })
+        )
+      ).toBe(false);
+    }
+  );
+
   it("accepts any non-empty extension key that starts with x-", () => {
     const fixture = commonEnvelope({
       extensions: {

--- a/test/fixtures.test.ts
+++ b/test/fixtures.test.ts
@@ -40,7 +40,9 @@ describe("conformance fixture validation", () => {
 
   it("covers the currently published fixture suite", () => {
     expect(result.cases.map((validationCase) => path.relative(repoRoot, validationCase.fixturePath))).toEqual([
+      "fixtures/common/v1/valid/agent-actor-envelope.json",
       "fixtures/common/v1/valid/common-envelope.json",
+      "fixtures/common/v1/invalid/bad-actor-type.json",
       "fixtures/common/v1/invalid/bad-classification.json",
       "fixtures/common/v1/invalid/bad-extension-key.json",
       "fixtures/common/v1/invalid/bad-timestamp.json",


### PR DESCRIPTION
## Summary
- update ActorRef actorType to the Phase 1 design enum
- migrate fixtures away from legacy service and add agent/service coverage
- document the actor type vocabulary and add focused schema tests

## Verification
- npm test -- test/common-schema.test.ts
- npm run check:fixtures
- npm test

Closes #21

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for new actor types: workflow, api_client, connector, executor, and agent in audit events and system envelopes.

* **Bug Fixes**
  * Removed deprecated "service" actor type; all references now use appropriate specialized actor types.

* **Documentation**
  * Updated to clarify allowed actor type values in system specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->