### PR TITLE
Align v1 public ID prefixes

### DIFF
--- a/docs/EIP-0000-common-types.md
+++ b/docs/EIP-0000-common-types.md
@@ -14,10 +14,13 @@ WorkItemRef, ChangeRequestRef, and EvidenceBundleRef are references. They do
 not redefine the referenced record and must not be treated as proof that the
 referenced record exists or is authorized.
 
-All common identifiers use `PrefixedId`: a lowercase semantic prefix, an
-underscore, and an opaque suffix. The prefix states the identifier family; the
-suffix is opaque and must not be parsed for tenant, repository, account, issue,
-environment, or authorization facts.
+All common identifiers use `PrefixedId`: a registered 2-8 character lowercase
+semantic prefix, an underscore, and an opaque suffix. The prefix states the
+identifier family; the suffix is opaque and must not be parsed for tenant,
+repository, account, issue, environment, or authorization facts. Public v1
+artifact families use short prefixes such as `req_`, `run_`, `sts_`, `evt_`,
+`evb_`, and `corr_`; long, hyphenated, or drifted prefixes such as
+`runrequest_`, `runreq_`, and `executor-run_` are not canonical.
 
 ## Timestamp Conventions
 

--- a/fixtures/audit-event/v1/invalid/bad-event-type.json
+++ b/fixtures/audit-event/v1/invalid/bad-event-type.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "eip.audit-event.v1",
-  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9D",
+  "id": "evt_01HVAX8J2K6T3QW4R5Y7M8N9D",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
   "subject": {
-    "subjectId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    "subjectId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
     "subjectType": "run-request"
   },
   "type": "loop-run-requested",

--- a/fixtures/audit-event/v1/invalid/forbidden-timestamp.json
+++ b/fixtures/audit-event/v1/invalid/forbidden-timestamp.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "eip.audit-event.v1",
-  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9E",
+  "id": "evt_01HVAX8J2K6T3QW4R5Y7M8N9E",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
   "subject": {
-    "subjectId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    "subjectId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
     "subjectType": "run-request"
   },
   "type": "loop.run.requested",

--- a/fixtures/audit-event/v1/valid/flow-step-completed.json
+++ b/fixtures/audit-event/v1/valid/flow-step-completed.json
@@ -1,8 +1,8 @@
 {
   "schemaVersion": "eip.audit-event.v1",
-  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9B",
+  "id": "evt_01HVAX8J2K6T3QW4R5Y7M8N9B",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
-  "causationId": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9A",
+  "causationId": "evt_01HVAX8J2K6T3QW4R5Y7M8N9A",
   "subject": {
     "subjectId": "flowstep_01HVAX8J2K6T3QW4R5Y7M8N9C",
     "subjectType": "flow-step",

--- a/fixtures/audit-event/v1/valid/loop-run-requested.json
+++ b/fixtures/audit-event/v1/valid/loop-run-requested.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "eip.audit-event.v1",
-  "id": "auditevent_01HVAX8J2K6T3QW4R5Y7M8N9A",
+  "id": "evt_01HVAX8J2K6T3QW4R5Y7M8N9A",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
   "subject": {
-    "subjectId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+    "subjectId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
     "subjectType": "run-request",
     "externalRef": "github-issue-6"
   },

--- a/fixtures/common/v1/invalid/bad-actor-type.json
+++ b/fixtures/common/v1/invalid/bad-actor-type.json
@@ -11,13 +11,13 @@
     "sourceType": "fixture"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001"
+    "workItemId": "workitem_protocol0001"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003"
+    "changeRequestId": "cr_issue0003"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001"
+    "evidenceBundleId": "evb_common0001"
   },
   "classification": "public"
 }

--- a/fixtures/common/v1/invalid/bad-classification.json
+++ b/fixtures/common/v1/invalid/bad-classification.json
@@ -11,13 +11,13 @@
     "sourceType": "fixture"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001"
+    "workItemId": "workitem_protocol0001"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003"
+    "changeRequestId": "cr_issue0003"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001"
+    "evidenceBundleId": "evb_common0001"
   },
   "classification": "secret"
 }

--- a/fixtures/common/v1/invalid/bad-extension-key.json
+++ b/fixtures/common/v1/invalid/bad-extension-key.json
@@ -11,13 +11,13 @@
     "sourceType": "fixture"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001"
+    "workItemId": "workitem_protocol0001"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003"
+    "changeRequestId": "cr_issue0003"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001"
+    "evidenceBundleId": "evb_common0001"
   },
   "classification": "public",
   "extensions": {

--- a/fixtures/common/v1/invalid/bad-timestamp.json
+++ b/fixtures/common/v1/invalid/bad-timestamp.json
@@ -11,13 +11,13 @@
     "sourceType": "fixture"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001"
+    "workItemId": "workitem_protocol0001"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003"
+    "changeRequestId": "cr_issue0003"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001"
+    "evidenceBundleId": "evb_common0001"
   },
   "classification": "public"
 }

--- a/fixtures/common/v1/invalid/missing-actor-binding.json
+++ b/fixtures/common/v1/invalid/missing-actor-binding.json
@@ -10,13 +10,13 @@
     "sourceType": "fixture"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001"
+    "workItemId": "workitem_protocol0001"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003"
+    "changeRequestId": "cr_issue0003"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001"
+    "evidenceBundleId": "evb_common0001"
   },
   "classification": "public"
 }

--- a/fixtures/common/v1/valid/agent-actor-envelope.json
+++ b/fixtures/common/v1/valid/agent-actor-envelope.json
@@ -13,15 +13,15 @@
     "externalRef": "public-fixture/agent-actor-envelope"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001",
+    "workItemId": "workitem_protocol0001",
     "title": "Define common schema conventions"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003",
+    "changeRequestId": "cr_issue0003",
     "status": "open"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001",
+    "evidenceBundleId": "evb_common0001",
     "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   },
   "classification": "public"

--- a/fixtures/common/v1/valid/common-envelope.json
+++ b/fixtures/common/v1/valid/common-envelope.json
@@ -13,15 +13,15 @@
     "externalRef": "public-fixture/common-envelope"
   },
   "workItem": {
-    "workItemId": "work-item_protocol0001",
+    "workItemId": "workitem_protocol0001",
     "title": "Define common schema conventions"
   },
   "changeRequest": {
-    "changeRequestId": "change-request_issue0003",
+    "changeRequestId": "cr_issue0003",
     "status": "open"
   },
   "evidenceBundle": {
-    "evidenceBundleId": "evidence-bundle_common0001",
+    "evidenceBundleId": "evb_common0001",
     "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
   },
   "classification": "public",

--- a/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
+++ b/fixtures/evidence-bundle-ref/v1/invalid/bad-checksum.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.evidence-bundle-ref.v1",
-  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "type": "local_path",
   "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",

--- a/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
+++ b/fixtures/evidence-bundle-ref/v1/invalid/raw-secret-uri.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.evidence-bundle-ref.v1",
-  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "type": "file_uri",
   "uri": "file://user:REDACTED_FIXTURE_SECRET_PLACEHOLDER@evidence.example.test/bundle.json",

--- a/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
+++ b/fixtures/evidence-bundle-ref/v1/valid/file-uri.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.evidence-bundle-ref.v1",
-  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "type": "file_uri",
   "uri": "file:///var/lib/ensen/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",

--- a/fixtures/evidence-bundle-ref/v1/valid/local-path.json
+++ b/fixtures/evidence-bundle-ref/v1/valid/local-path.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.evidence-bundle-ref.v1",
-  "id": "evidencebundle_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "id": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "type": "local_path",
   "uri": "artifacts/evidence/run-01HV9ZX8J2K6T3QW4R5Y7M8N9Q/bundle.json",

--- a/fixtures/run-request/v1/invalid/bad-schema-version.json
+++ b/fixtures/run-request/v1/invalid/bad-schema-version.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-request.v2",
-  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2CB",
   "idempotencyKey": "github-issue-4-attempt-1",
   "source": {

--- a/fixtures/run-request/v1/invalid/raw-secret.json
+++ b/fixtures/run-request/v1/invalid/raw-secret.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-request.v1",
-  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2DB",
   "idempotencyKey": "manual-request-20260429-2",
   "source": {

--- a/fixtures/run-request/v1/invalid/source-string.json
+++ b/fixtures/run-request/v1/invalid/source-string.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-request.v1",
-  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2EA",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2EA",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2EB",
   "idempotencyKey": "manual-request-20260429-3",
   "source": "github",

--- a/fixtures/run-request/v1/invalid/unknown-top-level-field.json
+++ b/fixtures/run-request/v1/invalid/unknown-top-level-field.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-request.v1",
-  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2FA",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2FA",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2FB",
   "idempotencyKey": "github-issue-4-attempt-1",
   "source": {

--- a/fixtures/run-request/v1/valid/github-issue-request.json
+++ b/fixtures/run-request/v1/valid/github-issue-request.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-request.v1",
-  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
   "idempotencyKey": "github-issue-4",
   "source": {

--- a/fixtures/run-request/v1/valid/manual-request.json
+++ b/fixtures/run-request/v1/valid/manual-request.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-request.v1",
-  "id": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "id": "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
   "idempotencyKey": "manual-request-20260429-1",
   "source": {

--- a/fixtures/run-result/v1/invalid/missing-request-id.json
+++ b/fixtures/run-result/v1/invalid/missing-request-id.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": "eip.run-result.v1",
-  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
   "status": "succeeded",
   "completedAt": "2026-04-29T03:00:00Z"

--- a/fixtures/run-result/v1/invalid/running-status.json
+++ b/fixtures/run-result/v1/invalid/running-status.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "eip.run-result.v1",
-  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9X",
-  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9X",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2DA",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9Y",
   "status": "running",
   "completedAt": "2026-04-29T03:10:00Z"

--- a/fixtures/run-result/v1/valid/blocked-result.json
+++ b/fixtures/run-result/v1/valid/blocked-result.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "eip.run-result.v1",
-  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
-  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2BA",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2BB",
   "status": "blocked",
   "completedAt": "2026-04-29T02:40:00Z",

--- a/fixtures/run-result/v1/valid/failed-result.json
+++ b/fixtures/run-result/v1/valid/failed-result.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "eip.run-result.v1",
-  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
-  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2CA",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
   "status": "failed",
   "completedAt": "2026-04-29T02:50:00Z",

--- a/fixtures/run-result/v1/valid/succeeded-result.json
+++ b/fixtures/run-result/v1/valid/succeeded-result.json
@@ -1,19 +1,19 @@
 {
   "schemaVersion": "eip.run-result.v1",
-  "id": "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
-  "requestId": "runreq_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
+  "id": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
+  "requestId": "req_01HV7Y8M8F2KQ5W3P9R6T4N2AB",
   "correlationId": "corr_01HV7Y8M8F2KQ5W3P9R6T4N2AC",
   "status": "succeeded",
   "completedAt": "2026-04-29T02:30:00Z",
   "changeRequests": [
     {
-      "changeRequestId": "changereq_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      "changeRequestId": "cr_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
       "status": "open"
     }
   ],
   "evidenceBundles": [
     {
-      "evidenceBundleId": "evidence_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
+      "evidenceBundleId": "evb_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
       "digest": "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
     }
   ],

--- a/fixtures/run-status/v1/invalid/final-result-only-fields.json
+++ b/fixtures/run-status/v1/invalid/final-result-only-fields.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "eip.run-status.v1",
-  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
-  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9W",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "status": "completed",
   "observedAt": "2026-04-29T00:05:00Z",

--- a/fixtures/run-status/v1/valid/accepted-snapshot.json
+++ b/fixtures/run-status/v1/valid/accepted-snapshot.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": "eip.run-status.v1",
-  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
-  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
   "status": "accepted",
   "observedAt": "2026-04-29T00:00:00Z",

--- a/fixtures/run-status/v1/valid/completed-snapshot.json
+++ b/fixtures/run-status/v1/valid/completed-snapshot.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "eip.run-status.v1",
-  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
-  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9U",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
-  "runId": "executor-run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "runId": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
   "status": "completed",
   "observedAt": "2026-04-29T00:05:00Z",
   "message": "Run completed. Retrieve final details from RunResult."

--- a/fixtures/run-status/v1/valid/running-snapshot.json
+++ b/fixtures/run-status/v1/valid/running-snapshot.json
@@ -1,9 +1,9 @@
 {
   "schemaVersion": "eip.run-status.v1",
-  "id": "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
-  "requestId": "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+  "id": "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+  "requestId": "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
   "correlationId": "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
-  "runId": "executor-run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
+  "runId": "run_01HV9ZX8J2K6T3QW4R5Y7M8N9V",
   "status": "running",
   "observedAt": "2026-04-29T00:01:00Z",
   "message": "Executor is running validation.",

--- a/schemas/eip.common.v1.schema.json
+++ b/schemas/eip.common.v1.schema.json
@@ -54,8 +54,8 @@
   "$defs": {
     "PrefixedId": {
       "type": "string",
-      "description": "Stable protocol identifier with a lowercase semantic prefix, underscore separator, and opaque suffix.",
-      "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$"
+      "description": "Stable protocol identifier with a registered 2-8 character lowercase semantic prefix, underscore separator, and opaque suffix.",
+      "pattern": "^(?:actor|artifact|corr|cr|evb|evt|flowstep|policy|pr|repo|req|run|source|sts|workitem)_[A-Za-z0-9][A-Za-z0-9._~-]{5,127}$"
     },
     "CorrelationId": {
       "type": "string",

--- a/test/common-schema.test.ts
+++ b/test/common-schema.test.ts
@@ -89,6 +89,25 @@ describe("EIP-0000 common schema", () => {
     }
   );
 
+  it.each(["req_", "run_", "sts_", "evt_", "evb_", "corr_"])(
+    "accepts canonical short semantic PrefixedId prefix: %s",
+    (prefix) => {
+      expect(
+        validate(commonEnvelope({ artifactId: `${prefix}01HV9ZX8J2K6T3QW4R5Y7M8N9A` })),
+        JSON.stringify(validate.errors, null, 2)
+      ).toBe(true);
+    }
+  );
+
+  it.each(["runreq_", "runresult_", "runstatus_", "auditevent_", "evidencebundle_", "executor-run_"])(
+    "rejects non-canonical drifted PrefixedId prefix: %s",
+    (prefix) => {
+      expect(
+        validate(commonEnvelope({ artifactId: `${prefix}01HV9ZX8J2K6T3QW4R5Y7M8N9A` }))
+      ).toBe(false);
+    }
+  );
+
   it.each(["human", "workflow", "system", "api_client", "connector", "executor", "agent"])(
     "accepts design-listed ActorRef actorType: %s",
     (actorType) => {

--- a/test/run-result-schema.test.ts
+++ b/test/run-result-schema.test.ts
@@ -39,8 +39,8 @@ describe("EIP-0002 RunResult schema", () => {
   function runResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
     return {
       schemaVersion: "eip.run-result.v1",
-      id: "runresult_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
-      requestId: "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      id: "run_01HV9ZX8J2K6T3QW4R5Y7M8N9P",
+      requestId: "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
       correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
       status: "succeeded",
       completedAt: "2026-04-29T00:00:00Z",

--- a/test/run-status-schema.test.ts
+++ b/test/run-status-schema.test.ts
@@ -41,8 +41,8 @@ describe("EIP-0005 RunStatusSnapshot schema", () => {
   ): Record<string, unknown> {
     return {
       schemaVersion: "eip.run-status.v1",
-      id: "runstatus_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
-      requestId: "runrequest_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
+      id: "sts_01HV9ZX8J2K6T3QW4R5Y7M8N9S",
+      requestId: "req_01HV9ZX8J2K6T3QW4R5Y7M8N9Q",
       correlationId: "corr_01HV9ZX8J2K6T3QW4R5Y7M8N9R",
       status: "running",
       observedAt: "2026-04-29T00:00:00Z",
@@ -99,7 +99,7 @@ describe("EIP-0005 RunStatusSnapshot schema", () => {
     expect(
       validate(
         runStatusSnapshot({
-          runId: "executor-run_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
+          runId: "run_01HV9ZX8J2K6T3QW4R5Y7M8N9T",
           message: "Executor is running verification.",
           progress: {
             current: 2,


### PR DESCRIPTION
## Summary
- tighten PrefixedId to the registered v1 short semantic prefix set
- migrate public fixtures from drifted prefixes to req_, run_, sts_, evt_, evb_, and related short reference prefixes
- add focused schema coverage rejecting drifted long or hyphenated prefixes

## Verification
- npm test -- test/common-schema.test.ts test/run-request-schema.test.ts test/run-result-schema.test.ts test/audit-event-schema.test.ts test/evidence-bundle-ref-schema.test.ts test/run-status-schema.test.ts
- npm run check:fixtures
- npm run check:schema-ids
- npm test

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated specification clarifying identifier naming conventions with registered 2-8 character lowercase prefixes.

* **Schema**
  * Enforced stricter identifier validation rules using explicit allowlist of approved prefixes.

* **Tests**
  * Added validation test coverage for identifier naming standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->