### PR TITLE
[codex] Add consumer conformance handoff checklist

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@ Start here:
   consumption and fixture handoff guidance.
 - `integration/ensen-flow-consumer-guide.md` defines flow-side protocol
   consumption and fixture handoff guidance.
+- `integration/consumer-conformance-handoff-checklist.md` defines the snapshot
+  evidence checklist for Loop and Flow conformance handoffs.
 - `integration/cross-repo-change-policy.md` defines the protocol-first
   cross-repo change process.
 - `security.md` defines security posture for protocol artifacts.

--- a/docs/integration/consumer-conformance-handoff-checklist.md
+++ b/docs/integration/consumer-conformance-handoff-checklist.md
@@ -1,0 +1,82 @@
+# Consumer Conformance Handoff Checklist
+
+Use this checklist when Ensen-loop, Ensen-flow, or a domain-specific consumer
+vendors or copies an Ensen-protocol release snapshot into its own conformance
+tests. The goal is to prove which protocol contract the consumer uses without
+turning Ensen-protocol into a shared runtime package.
+
+Ensen-protocol is a contract repository and not a runtime dependency. Consumer
+repositories may copy protocol documents, schemas, and fixtures into their own
+test trees, but they must not import runtime code, SDKs, adapters, workflow
+modules, connector modules, or private helpers from this repository.
+
+## Snapshot Record
+
+Record the snapshot in the consumer repository near the conformance tests:
+
+- protocol snapshot version: the Ensen-protocol release tag, commit, or other
+  immutable snapshot identifier copied by the consumer;
+- source repository: `TommyKammy/Ensen-protocol`;
+- copied schema paths: the repo-relative `schemas/` files copied into the
+  consumer test tree;
+- copied fixture paths: the repo-relative `fixtures/<artifact>/v<version>/`
+  directories copied into the consumer test tree;
+- consumer conformance command evidence: sanitized command names, exit status,
+  and relevant log excerpts from the consumer repository;
+- local conformance test owner: the consumer-side test file or task that reads
+  the copied snapshot;
+- exceptions: unsupported optional fields or deferred compatibility work, each
+  linked to an explicit consumer follow-up issue.
+
+Use placeholders such as `<protocol-snapshot>`, `<consumer-repo>`,
+`<consumer-conformance-command>`, `<schema-copy-root>`, and
+`<fixture-copy-root>` when a concrete local value would expose workstation-local
+paths, customer data, repository mutations, or secrets.
+
+## Required Artifact Checks
+
+The consumer handoff should name every public artifact family it copies or
+intentionally excludes:
+
+| Artifact | Protocol schema | Fixture family | Consumer check |
+| --- | --- | --- | --- |
+| RunRequest | `schemas/eip.run-request.v1.schema.json` | `fixtures/run-request/v1/` | Validate accepted run input and reject invalid request fixtures at the consumer boundary. |
+| RunStatusSnapshot | `schemas/eip.run-status.v1.schema.json` | `fixtures/run-status/v1/` | Validate async status snapshots and document unsupported optional fields. |
+| RunResult | `schemas/eip.run-result.v1.schema.json` | `fixtures/run-result/v1/` | Validate terminal run outcomes and keep consumer-local result examples separate. |
+| AuditEvent | `schemas/eip.audit-event.v1.schema.json` | `fixtures/audit-event/v1/` | Validate emitted or consumed audit events without adding customer-specific audit samples to protocol fixtures. |
+| EvidenceBundleRef | `schemas/eip.evidence-bundle-ref.v1.schema.json` | `fixtures/evidence-bundle-ref/v1/` | Validate evidence references with placeholder roots or sanitized URIs only. |
+
+If a consumer does not use one of these artifacts, record the explicit reason in
+the consumer snapshot record. Do not infer conformance from a neighboring
+artifact, runtime naming convention, or copied file shape alone.
+
+## Evidence Hygiene
+
+Consumer conformance evidence should be sanitized before it is copied into an
+issue, pull request, release note, or handoff record:
+
+- include repo-relative commands such as `npm test`, task names, or documented
+  environment variable names;
+- include the protocol snapshot version and copied schema paths and copied
+  fixture paths;
+- exclude raw secrets, credential-bearing URIs, customer data, tenant-specific
+  identifiers, real repository mutation payloads, and workstation-local paths;
+- replace local roots with placeholders such as `<codex-supervisor-root>`,
+  `<supervisor-config-path>`, `<consumer-worktree>`, or `<fixture-copy-root>`;
+- keep valid and invalid fixture results separate so fail-closed coverage is
+  visible.
+
+The evidence proves that the consumer checked its local parser or adapter
+boundary against the copied protocol snapshot. It does not create a runtime
+dependency on Ensen-protocol.
+
+## Protocol-First Routing
+
+File protocol ambiguity in Ensen-protocol first. Clarify the intended contract
+in EIP text, schemas, fixtures, compatibility notes, or this checklist before
+opening Ensen-loop or Ensen-flow implementation fixes.
+
+After the protocol expectation is explicit, open downstream Loop or Flow
+follow-up issues that reference the Ensen-protocol issue and the protocol
+snapshot version. Downstream issues should describe the consumer-specific
+implementation or test change, not redefine the protocol expectation.

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -49,4 +49,37 @@ describe("integration handoff documentation", () => {
     expect(policy).toMatch(/must not import .*implementation/i);
     expect(hasWorkstationHomePath(policy)).toBe(false);
   });
+
+  it("documents consumer conformance handoff evidence", () => {
+    const checklist = readDoc(
+      "docs/integration/consumer-conformance-handoff-checklist.md"
+    );
+    const docsIndex = readDoc("docs/README.md");
+
+    for (const expected of [
+      "protocol snapshot version",
+      "copied schema paths",
+      "copied fixture paths",
+      "consumer conformance command evidence",
+      "RunRequest",
+      "RunStatusSnapshot",
+      "RunResult",
+      "AuditEvent",
+      "EvidenceBundleRef",
+      "contract repository",
+      "not a runtime dependency",
+      "protocol ambiguity"
+    ]) {
+      expect(checklist).toContain(expected);
+    }
+
+    expect(checklist).toMatch(/Ensen-protocol first/i);
+    expect(checklist).toMatch(/Ensen-loop|Loop/i);
+    expect(checklist).toMatch(/Ensen-flow|Flow/i);
+    expect(checklist).toMatch(/sanitized/i);
+    expect(hasWorkstationHomePath(checklist)).toBe(false);
+    expect(docsIndex).toContain(
+      "integration/consumer-conformance-handoff-checklist.md"
+    );
+  });
 });

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -74,8 +74,8 @@ describe("integration handoff documentation", () => {
     }
 
     expect(checklist).toMatch(/Ensen-protocol first/i);
-    expect(checklist).toMatch(/Ensen-loop|Loop/i);
-    expect(checklist).toMatch(/Ensen-flow|Flow/i);
+    expect(checklist).toMatch(/\bEnsen-loop\b/i);
+    expect(checklist).toMatch(/\bEnsen-flow\b/i);
     expect(checklist).toMatch(/sanitized/i);
     expect(hasWorkstationHomePath(checklist)).toBe(false);
     expect(docsIndex).toContain(


### PR DESCRIPTION
## Summary
- Add a protocol-side consumer conformance handoff checklist for copied or vendored snapshots.
- Cover snapshot version, copied schema and fixture paths, sanitized command evidence, and required public artifact families.
- Link the checklist from the docs index and add a focused docs regression test.

## Verification
- npm test -- test/integration-docs.test.ts
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:spec-boundary

Closes #30.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Consumer Conformance Handoff Checklist guide describing snapshot record fields, artifact-family validation, evidence hygiene rules (sanitization, no workstation paths), and guidance for resolving protocol ambiguities and filing follow-up issues.
  * Updated docs index to include the new integration guide.
* **Tests**
  * Added an integration test to validate the checklist content, required checklist items, terminology, and sanitization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->