### PR TITLE
PROTOCOL-021: Add protocol snapshot policy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ executor, workflow engine, connector package, or loop service.
 - `fixtures/` is reserved for example inputs and outputs used to test contracts.
 - `openapi/` is reserved for future transport-level API descriptions.
 - `docs/conformance.md` defines fixture validation and vendoring guidance.
+- `docs/protocol-snapshot-policy.md` defines release snapshot handoff guidance
+  for downstream protocol consumers.
 - `scripts/check-spec-only-boundary.ts` enforces that runtime implementation
   directories are not added to this repository.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ Start here:
 - `versioning.md` defines versioning expectations.
 - `compatibility.md` defines compatibility and deprecation rules.
 - `conformance.md` defines fixture validation and vendoring guidance.
+- `protocol-snapshot-policy.md` defines the release snapshot policy for Loop,
+  Flow, and future protocol consumers.
 - `integration/ensen-loop-consumer-guide.md` defines loop-side protocol
   consumption and fixture handoff guidance.
 - `integration/ensen-flow-consumer-guide.md` defines flow-side protocol

--- a/docs/integration/consumer-conformance-handoff-checklist.md
+++ b/docs/integration/consumer-conformance-handoff-checklist.md
@@ -5,6 +5,10 @@ vendors or copies an Ensen-protocol release snapshot into its own conformance
 tests. The goal is to prove which protocol contract the consumer uses without
 turning Ensen-protocol into a shared runtime package.
 
+Use `../protocol-snapshot-policy.md` to decide what belongs in the snapshot
+record, when to copy or vendor artifacts, and when to open a protocol follow-up
+issue before downstream implementation work.
+
 Ensen-protocol is a contract repository and not a runtime dependency. Consumer
 repositories may copy protocol documents, schemas, and fixtures into their own
 test trees, but they must not import runtime code, SDKs, adapters, workflow

--- a/docs/protocol-snapshot-policy.md
+++ b/docs/protocol-snapshot-policy.md
@@ -1,0 +1,101 @@
+# Protocol Snapshot Policy
+
+A protocol snapshot is the release or tagged contract artifacts from
+Ensen-protocol that a consumer copies or vendors for local conformance tests. It
+is not a runtime dependency, SDK, transport API, shared implementation package,
+workflow module, connector module, or source of private helpers.
+
+Ensen-loop, Ensen-flow, domain-specific Flow variants, and future consumers
+should treat a snapshot as immutable protocol evidence: Markdown contract text,
+JSON Schemas, public fixtures, compatibility guidance, and the validation
+commands that proved the snapshot was publishable.
+
+## Snapshot Metadata
+
+Each consumer snapshot record should include:
+
+- protocol version: the Ensen-protocol release version the consumer adopted;
+- commit or tag: the immutable Git commit, release tag, or signed release
+  pointer used for the copied artifacts;
+- schema families: the repo-relative `schemas/` files copied or intentionally
+  excluded;
+- fixture families: the repo-relative `fixtures/<artifact>/v<version>/`
+  directories copied or intentionally excluded;
+- contract documents: the EIP Markdown files or compatibility notes the
+  consumer used to interpret the schema and fixture families;
+- validation commands: sanitized command names and pass/fail results for the
+  protocol snapshot and the consumer-side conformance run;
+- consumer owner: the local consumer test, task, or adapter boundary that reads
+  the copied snapshot;
+- exceptions: unsupported optional fields, deferred compatibility work, or
+  intentional exclusions, each linked to an explicit follow-up issue.
+
+Use placeholders such as `<protocol-snapshot>`, `<consumer-repo>`,
+`<schema-copy-root>`, `<fixture-copy-root>`, and
+`<consumer-conformance-command>` when a real local value would expose a secret,
+customer value, workstation-local path, or repository mutation payload.
+
+## Copy Or Vendor
+
+Consumers should copy or vendor protocol artifacts when the existing protocol
+contract is clear and the consumer only needs local test inputs or local parser
+coverage. Keep copied artifacts under consumer-owned test or conformance paths,
+preserve the upstream relative paths where practical, and record the protocol
+version plus commit or tag next to the copied files.
+
+Copying or vendoring is appropriate for:
+
+- schema families that already describe the consumer boundary;
+- fixture families that already cover valid and invalid behavior;
+- compatibility notes that explain existing optional or deprecated fields;
+- release snapshots used to prove Loop and Flow consume the same contract
+  without sharing runtime code.
+
+Consumers must keep runtime credentials, tenant identifiers, customer examples,
+host-specific roots, and workstation-local paths out of copied protocol
+artifacts. Local examples may exist in the consumer repository, but they should
+be labeled as consumer-local examples, not protocol conformance fixtures.
+
+## Open A Protocol Follow-Up
+
+Open a protocol follow-up issue before downstream implementation work when the
+consumer cannot prove the boundary from the copied snapshot. The follow-up
+should stay in Ensen-protocol until the contract is explicit.
+
+Open the protocol issue when:
+
+- schema text, fixture behavior, compatibility guidance, or handoff guidance is
+  ambiguous;
+- Loop and Flow would need to interpret the same artifact differently;
+- the consumer needs a new schema family, fixture family, or validation rule;
+- a fixture would require secrets, customer data, real repository mutation, or a
+  workstation-local path to explain the behavior;
+- a downstream workaround would redefine the protocol expectation instead of
+  testing a consumer-owned adapter.
+
+After the protocol issue lands, open downstream Ensen-loop or Ensen-flow issues
+that reference the protocol issue, protocol version, and commit or tag. Those
+issues should implement or test the consumer boundary; they should not redefine
+the protocol contract.
+
+## Release Handoff
+
+Before a protocol release is handed to consumers, the release owner should
+record the snapshot handoff evidence:
+
+- protocol version and commit or tag selected for the release;
+- schema families and fixture families included in the snapshot;
+- any intentionally excluded schema families or fixture families;
+- compatibility notes that affect Loop, Flow, or future consumers;
+- validation commands run from the repository root:
+
+```sh
+npm test
+npm run check:fixtures
+npm run check:public-fixtures
+npm run check:spec-boundary
+```
+
+The handoff should link to the
+`integration/consumer-conformance-handoff-checklist.md` checklist so each
+consumer records its copied snapshot and local conformance evidence.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -21,3 +21,20 @@ The first published protocol baseline is `v0.1.0`.
 - EIP-0005 RunStatusSnapshot
 - EIP-0006 conformance fixture and public fixture safety tooling
 - EIP-0007 Ensen-loop / Ensen-flow integration handoff notes
+
+## Release Snapshot Handoff
+
+Before publishing a protocol release for downstream consumers, run the snapshot
+handoff check from `protocol-snapshot-policy.md`:
+
+- record the protocol version and commit or tag selected for the release;
+- name the schema families and fixture families included in the snapshot;
+- name any intentionally excluded schema families or fixture families;
+- confirm the consumer conformance checklist is linked for Loop, Flow, and
+  future consumers;
+- record sanitized validation command evidence for `npm test`,
+  `npm run check:fixtures`, `npm run check:public-fixtures`, and
+  `npm run check:spec-boundary`.
+
+The release snapshot remains a set of copied or vendored contract artifacts. It
+does not create a runtime dependency on Ensen-protocol.

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -82,4 +82,39 @@ describe("integration handoff documentation", () => {
       "integration/consumer-conformance-handoff-checklist.md"
     );
   });
+
+  it("documents protocol snapshot policy and release handoff checks", () => {
+    const policy = readDoc("docs/protocol-snapshot-policy.md");
+    const checklist = readDoc(
+      "docs/integration/consumer-conformance-handoff-checklist.md"
+    );
+    const versioning = readDoc("docs/versioning.md");
+    const docsIndex = readDoc("docs/README.md");
+
+    for (const expected of [
+      "release or tagged contract artifacts",
+      "not a runtime dependency",
+      "protocol version",
+      "commit or tag",
+      "schema families",
+      "fixture families",
+      "validation commands",
+      "copy or vendor",
+      "protocol follow-up issue",
+      "Ensen-loop",
+      "Ensen-flow"
+    ]) {
+      expect(policy).toContain(expected);
+    }
+
+    expect(policy).toMatch(/npm test/);
+    expect(policy).toMatch(/npm run check:fixtures/);
+    expect(policy).toMatch(/npm run check:public-fixtures/);
+    expect(policy).toMatch(/npm run check:spec-boundary/);
+    expect(hasWorkstationHomePath(policy)).toBe(false);
+
+    for (const doc of [checklist, versioning, docsIndex]) {
+      expect(doc).toContain("protocol-snapshot-policy.md");
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add protocol snapshot policy docs for copied or vendored release artifacts
- link the policy from the docs index and consumer conformance checklist
- add release snapshot handoff guidance to versioning docs
- add integration-doc coverage for the policy, release handoff links, and path hygiene

## Verification
- npm test -- test/integration-docs.test.ts
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:spec-boundary

Closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new protocol snapshot policy documentation specifying snapshot handling, required metadata, copying/vendoring guidelines, and follow-up procedures.
  * Updated release process documentation with snapshot handoff validation requirements.
  * Enhanced documentation index with references to the new snapshot policy.

* **Tests**
  * Added validation tests for documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->