### PR TITLE
PROTOCOL-022: Harden unsupported EIP major guidance

### DIFF
--- a/docs/integration/consumer-conformance-handoff-checklist.md
+++ b/docs/integration/consumer-conformance-handoff-checklist.md
@@ -29,6 +29,9 @@ Record the snapshot in the consumer repository near the conformance tests:
   and relevant log excerpts from the consumer repository;
 - local conformance test owner: the consumer-side test file or task that reads
   the copied snapshot;
+- unsupported-major-version rejection: sanitized evidence naming the unsupported
+  EIP major version, the consumer boundary that rejected the artifact, and the
+  local check or test command that proved the fail-closed behavior;
 - exceptions: unsupported optional fields or deferred compatibility work, each
   linked to an explicit consumer follow-up issue.
 
@@ -54,6 +57,14 @@ If a consumer does not use one of these artifacts, record the explicit reason in
 the consumer snapshot record. Do not infer conformance from a neighboring
 artifact, runtime naming convention, or copied file shape alone.
 
+If a copied artifact declares an unsupported EIP major version, the consumer
+must fail closed at the parser, adapter, or ingestion boundary before runtime
+work is dispatched. The consumer must reject or block the artifact and record
+which protocol snapshot was active, which major versions were supported, the
+unsupported EIP major version that was rejected, and the consumer boundary that
+rejected the artifact. Do not downgrade, coerce, or silently accept the artifact
+as a supported major version.
+
 ## Evidence Hygiene
 
 Consumer conformance evidence should be sanitized before it is copied into an
@@ -63,6 +74,8 @@ issue, pull request, release note, or handoff record:
   environment variable names;
 - include the protocol snapshot version and copied schema paths and copied
   fixture paths;
+- include unsupported EIP major version rejection evidence when that fail-closed
+  path is exercised;
 - exclude raw secrets, credential-bearing URIs, customer data, tenant-specific
   identifiers, real repository mutation payloads, and workstation-local paths;
 - replace local roots with placeholders such as `<codex-supervisor-root>`,

--- a/docs/integration/ensen-flow-consumer-guide.md
+++ b/docs/integration/ensen-flow-consumer-guide.md
@@ -18,6 +18,10 @@ Use copied or vendored fixture snapshots for flow-side conformance tests:
 - record the Ensen-protocol commit used for the snapshot;
 - treat `valid/` fixtures as required compatibility examples;
 - treat `invalid/` fixtures as fail-closed regression coverage;
+- reject or block any unsupported EIP major version at the flow parser,
+  authoring, or ingestion boundary, and record sanitized evidence for the active
+  protocol snapshot, supported major versions, rejected version, and command or
+  test that proved the fail-closed behavior;
 - keep flow-specific credentials, tenant ids, host names, and operator paths out
   of the vendored snapshot.
 
@@ -39,3 +43,8 @@ label them separately from protocol conformance fixtures.
 When Ensen-flow needs a contract change, open or reference the Ensen-protocol
 issue first. Implement flow changes only after the protocol change is accepted,
 documented, and backed by schema or fixture updates where applicable.
+
+Unsupported EIP major version handling follows `../protocol-snapshot-policy.md`
+and `consumer-conformance-handoff-checklist.md`: Ensen-flow must fail closed
+instead of accepting, downgrading, coercing, or interpreting the artifact as a
+supported major version.

--- a/docs/integration/ensen-flow-consumer-guide.md
+++ b/docs/integration/ensen-flow-consumer-guide.md
@@ -20,8 +20,9 @@ Use copied or vendored fixture snapshots for flow-side conformance tests:
 - treat `invalid/` fixtures as fail-closed regression coverage;
 - reject or block any unsupported EIP major version at the flow parser,
   authoring, or ingestion boundary, and record sanitized evidence for the active
-  protocol snapshot, supported major versions, rejected version, and command or
-  test that proved the fail-closed behavior;
+  protocol snapshot, supported major versions, the rejected version, the flow
+  boundary that blocked it (`parser`, `authoring`, or `ingestion`), and the
+  command or test that proved the fail-closed behavior;
 - keep flow-specific credentials, tenant ids, host names, and operator paths out
   of the vendored snapshot.
 

--- a/docs/integration/ensen-loop-consumer-guide.md
+++ b/docs/integration/ensen-loop-consumer-guide.md
@@ -18,6 +18,10 @@ Use copied or vendored fixture snapshots for loop-side conformance tests:
 - record the Ensen-protocol commit used for the snapshot;
 - treat `valid/` fixtures as required compatibility examples;
 - treat `invalid/` fixtures as fail-closed regression coverage;
+- reject or block any unsupported EIP major version at the loop parser or
+  executor-dispatch boundary, and record sanitized evidence for the active
+  protocol snapshot, supported major versions, rejected version, and command or
+  test that proved the fail-closed behavior;
 - keep loop-specific credentials, tenant ids, host names, and operator paths out
   of the vendored snapshot.
 
@@ -39,3 +43,8 @@ label them separately from protocol conformance fixtures.
 When Ensen-loop needs a contract change, open or reference the Ensen-protocol
 issue first. Implement loop changes only after the protocol change is accepted,
 documented, and backed by schema or fixture updates where applicable.
+
+Unsupported EIP major version handling follows `../protocol-snapshot-policy.md`
+and `consumer-conformance-handoff-checklist.md`: Ensen-loop must fail closed
+instead of accepting, downgrading, coercing, or interpreting the artifact as a
+supported major version.

--- a/docs/integration/ensen-loop-consumer-guide.md
+++ b/docs/integration/ensen-loop-consumer-guide.md
@@ -20,7 +20,8 @@ Use copied or vendored fixture snapshots for loop-side conformance tests:
 - treat `invalid/` fixtures as fail-closed regression coverage;
 - reject or block any unsupported EIP major version at the loop parser or
   executor-dispatch boundary, and record sanitized evidence for the active
-  protocol snapshot, supported major versions, rejected version, and command or
+  protocol snapshot, supported major versions, the rejected version, the loop
+  boundary that blocked it (`parser` or `executor-dispatch`), and the command or
   test that proved the fail-closed behavior;
 - keep loop-specific credentials, tenant ids, host names, and operator paths out
   of the vendored snapshot.

--- a/docs/protocol-snapshot-policy.md
+++ b/docs/protocol-snapshot-policy.md
@@ -10,6 +10,12 @@ should treat a snapshot as immutable protocol evidence: Markdown contract text,
 JSON Schemas, public fixtures, compatibility guidance, and the validation
 commands that proved the snapshot was publishable.
 
+Consumers must fail closed when an artifact declares an unsupported EIP major
+version. A copied or vendored snapshot authorizes only the major versions named
+by that snapshot; unsupported EIP major version artifacts must be rejected or
+blocked rather than silently accepted, downgraded, coerced, or interpreted as a
+nearby supported major version.
+
 ## Snapshot Metadata
 
 Each consumer snapshot record should include:
@@ -27,6 +33,8 @@ Each consumer snapshot record should include:
   protocol snapshot and the consumer-side conformance run;
 - consumer owner: the local consumer test, task, or adapter boundary that reads
   the copied snapshot;
+- unsupported EIP major version evidence: sanitized command evidence naming the
+  consumer boundary that rejected or blocked the unsupported artifact;
 - exceptions: unsupported optional fields, deferred compatibility work, or
   intentional exclusions, each linked to an explicit follow-up issue.
 
@@ -87,6 +95,8 @@ record the snapshot handoff evidence:
 - schema families and fixture families included in the snapshot;
 - any intentionally excluded schema families or fixture families;
 - compatibility notes that affect Loop, Flow, or future consumers;
+- unsupported EIP major version fail-closed evidence linked to the consumer
+  conformance checklist;
 - validation commands run from the repository root:
 
 ```sh

--- a/docs/protocol-snapshot-policy.md
+++ b/docs/protocol-snapshot-policy.md
@@ -33,8 +33,9 @@ Each consumer snapshot record should include:
   protocol snapshot and the consumer-side conformance run;
 - consumer owner: the local consumer test, task, or adapter boundary that reads
   the copied snapshot;
-- unsupported EIP major version evidence: sanitized command evidence naming the
-  consumer boundary that rejected or blocked the unsupported artifact;
+- unsupported EIP major version evidence: sanitized evidence naming the
+  unsupported EIP major version, the consumer boundary that rejected or blocked
+  it, and the local check or test command that proved the fail-closed behavior;
 - exceptions: unsupported optional fields, deferred compatibility work, or
   intentional exclusions, each linked to an explicit follow-up issue.
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -9,6 +9,12 @@ components.
 - Fixtures and schemas identify the protocol version they target through
   `schemaVersion`, schema filenames, and versioned fixture directories.
 
+Consumers must fail closed when they encounter an unsupported EIP major version.
+Unsupported EIP major version artifacts must be rejected or blocked until the
+consumer has adopted a protocol snapshot that explicitly includes that major
+version. Consumers must not silently accept, downgrade, coerce, or interpret the
+artifact as a neighboring supported major version.
+
 The first published protocol baseline is `v0.1.0`.
 
 `v0.1.0` contains the v1 schema family and conformance fixture baseline:
@@ -32,6 +38,8 @@ handoff check from `protocol-snapshot-policy.md`:
 - name any intentionally excluded schema families or fixture families;
 - confirm the consumer conformance checklist is linked for Loop, Flow, and
   future consumers;
+- confirm unsupported EIP major version handling is covered by the consumer
+  conformance evidence;
 - record sanitized validation command evidence for `npm test`,
   `npm run check:fixtures`, `npm run check:public-fixtures`, and
   `npm run check:spec-boundary`.

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -135,6 +135,13 @@ describe("integration handoff documentation", () => {
 
     expect(checklist).toContain("unsupported-major-version rejection");
     expect(checklist).toContain("consumer boundary that rejected the artifact");
+    expect(policy).toContain("unsupported EIP major version evidence");
+    expect(policy).toContain("unsupported EIP major version, the consumer boundary");
+    expect(policy).toContain("local check or test command");
+    expect(loopGuide).toMatch(/loop\s+boundary that blocked it/);
+    expect(loopGuide).toContain("`parser` or `executor-dispatch`");
+    expect(flowGuide).toMatch(/flow\s+boundary that blocked it/);
+    expect(flowGuide).toContain("`parser`, `authoring`, or `ingestion`");
     expect(policy).toContain(
       "integration/consumer-conformance-handoff-checklist.md"
     );

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -117,4 +117,26 @@ describe("integration handoff documentation", () => {
       expect(doc).toContain("protocol-snapshot-policy.md");
     }
   });
+
+  it("documents unsupported EIP major version fail-closed behavior", () => {
+    const policy = readDoc("docs/protocol-snapshot-policy.md");
+    const checklist = readDoc(
+      "docs/integration/consumer-conformance-handoff-checklist.md"
+    );
+    const loopGuide = readDoc("docs/integration/ensen-loop-consumer-guide.md");
+    const flowGuide = readDoc("docs/integration/ensen-flow-consumer-guide.md");
+    const versioning = readDoc("docs/versioning.md");
+
+    for (const doc of [policy, checklist, loopGuide, flowGuide, versioning]) {
+      expect(doc).toMatch(/unsupported EIP major version/i);
+      expect(doc).toMatch(/fail closed/i);
+      expect(hasWorkstationHomePath(doc)).toBe(false);
+    }
+
+    expect(checklist).toContain("unsupported-major-version rejection");
+    expect(checklist).toContain("consumer boundary that rejected the artifact");
+    expect(policy).toContain(
+      "integration/consumer-conformance-handoff-checklist.md"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- require consumers to fail closed for unsupported EIP major versions
- add conformance handoff evidence expectations for unsupported-major rejection
- cover the guidance in Loop, Flow, snapshot policy, and versioning docs

## Verification
- npm test -- test/integration-docs.test.ts
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:schema-ids
- npm run check:spec-boundary

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Require fail-closed handling for unsupported EIP major versions: consumers must reject/block such artifacts (no downgrade, coercion, or silent acceptance).
  * Mandate sanitized evidence records capturing active protocol snapshot, supported vs. rejected major versions, rejecting boundary, and local command/test proving rejection.
  * Update integration guides and snapshot policy to enforce these handoff requirements.

* **Tests**
  * Add validation to ensure documentation consistently describes the required fail-closed behavior and evidence criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->