### PR TITLE
PROTOCOL-X2-001: Add loop-flow dry-run smoke fixture README

### DIFF
--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -20,3 +20,49 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
   fixtures.
 - `run-status/v1/valid/` contains valid EIP-0005 RunStatusSnapshot fixtures.
 - `run-status/v1/invalid/` contains negative RunStatusSnapshot fixtures.
+
+## X-Gate 2 Loop-Flow Dry-Run Smoke
+
+X-Gate 2 uses this public fixture suite to align the narrow loop-flow dry-run
+smoke path across Ensen-flow and Ensen-loop:
+
+```text
+RunRequest -> RunStatusSnapshot -> RunResult -> EvidenceBundleRef
+```
+
+The expected consumer snapshot is the `0.1.x protocol snapshot`. Flow and Loop
+must vendor or copy release snapshots of the protocol artifacts into their own
+consumer test trees. Ensen-protocol provides no runtime package, server, SDK,
+connector, or shared implementation for this smoke path.
+
+Use these EIP artifacts for the smoke contract:
+
+| Smoke artifact | Contract source | Fixture source |
+| --- | --- | --- |
+| RunRequest v1 | `schemas/eip.run-request.v1.schema.json` | `fixtures/run-request/v1/` |
+| RunStatusSnapshot v1 | `schemas/eip.run-status.v1.schema.json` | `fixtures/run-status/v1/` |
+| RunResult v1 | `schemas/eip.run-result.v1.schema.json` | `fixtures/run-result/v1/` |
+| EvidenceBundleRef v1 | `schemas/eip.evidence-bundle-ref.v1.schema.json` | `fixtures/evidence-bundle-ref/v1/` |
+
+Public smoke examples must stay synthetic and publishable. They must not include
+raw secret values, token values, customer data, real repository mutation
+payloads, or workstation-local path values. Use placeholders such as
+`<tenant-id>`, `<credential-ref>`, `<repository-ref>`, `<evidence-root>`, and
+`<supervisor-config-path>` when the smoke example needs to name a boundary
+without exposing local or private state.
+
+Route X-Gate 2 failures by ownership:
+
+- protocol gap: the EIP schema, fixture path, fixture safety rule, compatibility
+  guidance, or snapshot-copy policy is ambiguous or missing in Ensen-protocol.
+- loop gap: Ensen-loop cannot consume the copied snapshot, emit the expected
+  dry-run `RunStatusSnapshot` or `RunResult`, or reference an
+  `EvidenceBundleRef` without redefining the protocol contract.
+- flow gap: Ensen-flow cannot build the CLI-backed smoke request, preserve the
+  copied protocol snapshot, or classify the dry-run result without redefining
+  the protocol contract.
+
+Downstream X-Gate 2 issues should point back to these fixture expectations:
+
+- [Ensen-flow X-Gate 2 CLI-backed smoke issue](https://github.com/TommyKammy/Ensen-flow/issues/37)
+- [Ensen-loop X-Gate 2 dry-run output issue](https://github.com/TommyKammy/Ensen-loop/issues/35)

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -146,4 +146,40 @@ describe("integration handoff documentation", () => {
       "integration/consumer-conformance-handoff-checklist.md"
     );
   });
+
+  it("documents the X-Gate 2 loop-flow dry-run smoke fixture contract", () => {
+    const fixturesReadme = readDoc("fixtures/README.md");
+
+    for (const expected of [
+      "X-Gate 2",
+      "RunRequest -> RunStatusSnapshot -> RunResult -> EvidenceBundleRef",
+      "0.1.x protocol snapshot",
+      "schemas/eip.run-request.v1.schema.json",
+      "schemas/eip.run-status.v1.schema.json",
+      "schemas/eip.run-result.v1.schema.json",
+      "schemas/eip.evidence-bundle-ref.v1.schema.json",
+      "fixtures/run-request/v1/",
+      "fixtures/run-status/v1/",
+      "fixtures/run-result/v1/",
+      "fixtures/evidence-bundle-ref/v1/",
+      "vendor or copy release snapshots",
+      "protocol gap",
+      "loop gap",
+      "flow gap",
+      "Ensen-flow X-Gate 2 CLI-backed smoke issue",
+      "Ensen-loop X-Gate 2 dry-run output issue"
+    ]) {
+      expect(fixturesReadme).toContain(expected);
+    }
+
+    expect(fixturesReadme).toMatch(
+      /no runtime package,\s+server,\s+SDK,\s+connector,\s+or shared implementation/i
+    );
+    expect(fixturesReadme).toMatch(/raw secret/i);
+    expect(fixturesReadme).toMatch(/token/i);
+    expect(fixturesReadme).toMatch(/customer data/i);
+    expect(fixturesReadme).toMatch(/real repository mutation/i);
+    expect(fixturesReadme).toMatch(/workstation-local path/i);
+    expect(hasWorkstationHomePath(fixturesReadme)).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- document the X-Gate 2 Loop/Flow dry-run smoke fixture path in fixtures/README.md
- state the 0.1.x protocol snapshot expectation, copy/vendor policy, and no-runtime boundary
- add a focused docs regression for the smoke contract, safety rules, failure taxonomy, and downstream issue anchors

## Verification
- npm test -- test/integration-docs.test.ts
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:spec-boundary

Closes #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive fixture contract documentation specifying artifact pipeline, protocol versions, and constraints for public synthetic examples.

* **Tests**
  * Added validation test to ensure documentation completeness and compliance requirements are maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->