### PR TITLE
PROTOCOL-031: Define executor operation lifecycle semantics

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,8 @@ Start here:
 - `integration/executor-transport-capabilities.md` defines the transport-neutral
   executor transport capability model for submit, status, cancellation,
   evidence, polling, idempotency, and unsupported-operation reporting.
+- `integration/executor-operation-lifecycle.md` defines transport-neutral
+  lifecycle semantics for submit, status, cancel, and fetchEvidence.
 - `integration/cross-repo-change-policy.md` defines the protocol-first
   cross-repo change process.
 - `security.md` defines security posture for protocol artifacts.

--- a/docs/integration/executor-operation-lifecycle.md
+++ b/docs/integration/executor-operation-lifecycle.md
@@ -1,0 +1,160 @@
+# Executor Operation Lifecycle
+
+This document defines transport-neutral lifecycle semantics for executor
+operations described by the
+[executor transport capability model](executor-transport-capabilities.md). It
+does not define an HTTP API, OpenAPI endpoint, SDK, runtime server, queue
+adapter, connector implementation, or production readiness claim.
+It must not define OpenAPI endpoints and must not require SDK packages.
+
+Lifecycle statements describe how protocol consumers reason about `submit`,
+`status`, `cancel`, and `fetchEvidence` when existing EIP artifacts cross a
+trusted boundary. They preserve the current v1 schemas for RunRequest,
+RunStatusSnapshot, RunResult, and EvidenceBundleRef.
+
+## Shared Lifecycle Rules
+
+Each operation inherits the capability support levels from
+`executor-transport-capabilities.md`: `required baseline`, `optional`,
+`partial`, and `unsupported`. A boundary must publish which support level
+applies before consumers treat an operation as available.
+
+Lifecycle decisions must be anchored to authoritative boundary records and EIP
+artifacts. Do not infer a run, tenant, repository, account, issue, environment,
+or evidence linkage from path shape, naming conventions, status text, nearby
+metadata, or a matching `correlationId` alone.
+
+The `correlationId` traces related artifacts. It is not an authorization,
+idempotency, scope, or run-binding token. Retryable submission uses the
+RunRequest `idempotencyKey` together with the authoritative scope record. When
+scope, requester, provenance, idempotency, or artifact binding is missing or
+malformed, consumers should fail closed instead of accepting guessed context.
+
+Unsupported and out-of-subset operations are explicit outcomes. A consumer must
+reject, block, or route the operation without treating absence, timeout,
+operator text, or a different supported operation as proof of success.
+
+## submit lifecycle
+
+`submit` accepts a RunRequest at a trusted executor boundary and either binds it
+to an authoritative run record or records an authoritative rejection. Executor
+providers that accept work expose `submit` as the `required baseline`
+operation.
+
+Successful submission does not require an immediate RunResult. The first
+authoritative outcome may be a submitted run record, an accepted or queued
+RunStatusSnapshot, or a terminal RunResult if the boundary can complete the run
+synchronously. The artifact ids and scope binding must still point back to the
+submitted RunRequest.
+
+Retries of the same logical submission reuse the RunRequest `idempotencyKey`
+inside the same authoritative scope. A retry may return the existing bound run
+or rejection record, but it must not enqueue duplicate work by relying on
+`correlationId` alone.
+
+When `submit` is `partial`, the boundary must state the accepted request modes,
+work item types, scopes, or executor classes. Requests outside that subset stay
+blocked or rejected. When `submit` is `unsupported`, the boundary is not an
+executor provider for that exchange and must not synthesize a run.
+
+## status lifecycle
+
+`status` reads the authoritative run state for a RunRequest-bound run and emits
+RunStatusSnapshot observations. It is `optional` unless a provider advertises
+asynchronous execution or polling support.
+
+A RunStatusSnapshot may report accepted, queued, running, cancelling,
+cancelled, completed, failed, blocked, or unknown states permitted by the v1
+schema. A terminal snapshot is only a status echo. Final details, verification,
+diagnostics, and evidence references belong in RunResult.
+
+The status read must be tied to the authoritative run binding. Consumers should
+not construct snapshots from stale summaries, display badges, timeline text, or
+the newest-looking projection when those surfaces disagree with the lifecycle
+record.
+
+When `status` is `partial`, the boundary must name the supported states,
+polling interval expectations, or freshness limits. Outside that subset, the
+consumer reports unsupported or unknown status rather than fabricating
+completion. When `status` is `unsupported`, consumers must not poll a different
+surface and present it as protocol status.
+
+## cancel lifecycle
+
+`cancel` requests cancellation for an already submitted run that is explicitly
+bound to a RunRequest and authoritative run record. Cancellation is `optional`
+and best-effort unless Loop and Flow evidence proves a stronger boundary
+contract for a specific provider.
+
+A successful cancel request means the trusted boundary accepted the request to
+try cancellation. It does not guarantee immediate termination, rollback, or
+absence of side effects. Follow-up status may remain queued or running, move to
+cancelling, or eventually produce a cancelled, failed, blocked, or completed
+terminal state depending on the provider boundary.
+
+RunStatusSnapshot may expose `cancelling` or `cancelled` observations. RunResult
+may later record final `cancelled` status. Consumers must not mark a run
+cancelled from a timeout, missing response, operator note, or unsupported
+capability result.
+
+When `cancel` is `partial`, the boundary must name the supported cancellation
+window, such as only before dispatch or only while queued. Runs outside that
+window remain governed by status and RunResult. When `cancel` is `unsupported`,
+the run remains unchanged and the consumer reports unsupported cancellation.
+
+## fetchEvidence lifecycle
+
+`fetchEvidence` performs reference retrieval for evidence associated with a
+terminal or blocked run. It is `optional` and complements, but does not replace,
+EvidenceBundleRef entries in RunResult.
+
+The operation resolves or returns EvidenceBundleRef artifacts or storage
+references that the consumer is authorized to access. It is not direct evidence
+payload transport. Protocol artifacts do not embed evidence bodies, raw logs,
+credentials, token values, customer data, real repository mutation payloads, or
+workstation-local paths.
+
+Evidence references must stay bound to the authoritative run or result they
+describe. Consumers must not broaden an evidence reference from one run to a
+sibling run, same-parent issue, nearby timeline entry, or matching
+`correlationId` unless an explicit authoritative link says it applies there.
+
+When `fetchEvidence` is `partial`, the boundary must name the supported
+evidence roots, artifact classes, retention windows, or authorization modes.
+Outside that subset, the consumer reports unsupported evidence retrieval. When
+`fetchEvidence` is `unsupported`, the consumer may still preserve
+EvidenceBundleRef references already present in RunResult, but it must not
+invent retrievable evidence.
+
+## Supported, Partial, And Unsupported Behavior
+
+Capability support describes operation availability; lifecycle semantics
+describe what the operation means after it is invoked. A supported operation
+must identify its trusted boundary, accepted artifact shape, authoritative
+binding, and fail-closed behavior. A partial operation must identify the exact
+subset and the out-of-subset result. An unsupported operation must produce a
+clear unsupported-operation outcome or route the request without pretending the
+operation succeeded.
+
+The lifecycle does not add new schema fields. If a consumer needs a field or
+state that cannot be represented by RunRequest, RunStatusSnapshot, RunResult,
+or EvidenceBundleRef, route that as Protocol schema/spec ambiguity instead of
+adding consumer-local semantics that imply a shared contract.
+
+## Drift Routing
+
+Use
+[protocol-gap-and-conformance-drift.md](protocol-gap-and-conformance-drift.md)
+when lifecycle evidence disagrees across Protocol, Loop, and Flow.
+
+Route missing or ambiguous lifecycle contract text to Ensen-protocol as a
+protocol gap or schema/spec ambiguity. Route Loop provider behavior that
+contradicts explicit protocol text to Ensen-loop. Route Flow connector matrix,
+authoring, ingestion, or presentation behavior that contradicts explicit
+protocol text to Ensen-flow.
+
+Public examples and issue reports must use repo-relative paths, release tags,
+public issue links, and placeholders such as `<protocol-snapshot>`,
+`<consumer-repo>`, `<executor-boundary>`, `<run-id>`, and `<evidence-root>`.
+Do not include raw secrets, customer data, real repository mutation evidence,
+or workstation-local paths.

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -272,4 +272,43 @@ describe("integration handoff documentation", () => {
       "integration/executor-transport-capabilities.md"
     );
   });
+
+  it("documents executor operation lifecycle semantics", () => {
+    const lifecycle = readDoc(
+      "docs/integration/executor-operation-lifecycle.md"
+    );
+    const docsIndex = readDoc("docs/README.md");
+
+    for (const expected of [
+      "submit lifecycle",
+      "status lifecycle",
+      "cancel lifecycle",
+      "fetchEvidence lifecycle",
+      "RunRequest",
+      "RunStatusSnapshot",
+      "RunResult",
+      "EvidenceBundleRef",
+      "correlationId",
+      "idempotencyKey",
+      "required baseline",
+      "optional",
+      "partial",
+      "unsupported",
+      "best-effort",
+      "reference retrieval",
+      "executor-transport-capabilities.md",
+      "protocol-gap-and-conformance-drift.md",
+      "schema/spec ambiguity"
+    ]) {
+      expect(lifecycle).toContain(expected);
+    }
+
+    expect(lifecycle).toMatch(/must not define OpenAPI endpoints/i);
+    expect(lifecycle).toMatch(/must not require SDK/i);
+    expect(lifecycle).toMatch(/do not embed evidence bodies/i);
+    expect(hasWorkstationHomePath(lifecycle)).toBe(false);
+    expect(docsIndex).toContain(
+      "integration/executor-operation-lifecycle.md"
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add transport-neutral lifecycle semantics for submit, status, cancel, and fetchEvidence
- link lifecycle guidance from the docs index
- add integration-doc coverage for lifecycle semantics and path hygiene

## Verification
- npm test
- npm run check:public-fixtures
- npm run check:spec-boundary

Closes #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive protocol documentation defining transport-neutral lifecycle semantics for executor operations, covering operation binding, state management, idempotency handling, and evidence retrieval.
  * Documentation includes capability support requirements and guidance for implementing operations across different transport layers.

* **Tests**
  * Added validation test for executor operation lifecycle documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->