### PR TITLE
PROTOCOL-032: Define polling and terminal-state rules

### DIFF
--- a/docs/EIP-0002-run-result.md
+++ b/docs/EIP-0002-run-result.md
@@ -31,6 +31,26 @@ The in-progress states `queued` and `running` are not valid RunResult statuses.
 Producers that need to expose those states should use a RunStatusSnapshot
 artifact instead of emitting a RunResult early.
 
+## Terminal Handoff
+
+RunStatusSnapshot may report `completed`, `failed`, `blocked`, or `cancelled`
+before a consumer has retrieved the final RunResult. That terminal handoff is a
+two-step contract: the snapshot tells the consumer to stop treating the run as
+in progress, and the RunResult supplies the durable terminal artifact with
+completion time, verification, diagnostics, change request references, and
+evidence references.
+
+Consumers must not synthesize a RunResult from a terminal status echo,
+operator-facing status text, timeout, stale snapshot, or no-progress report. If
+the terminal RunResult is unavailable after a terminal snapshot, the consumer
+should report that final details are unavailable, retry the authoritative
+boundary according to its local policy, or escalate instead of inventing final
+semantics.
+
+See
+[`integration/executor-operation-lifecycle.md`](integration/executor-operation-lifecycle.md)
+for the transport-level polling rules that lead into this terminal artifact.
+
 ## Optional Fields
 
 - `changeRequests`: zero or more common v1 ChangeRequestRef objects produced or

--- a/docs/EIP-0005-run-status-snapshot.md
+++ b/docs/EIP-0005-run-status-snapshot.md
@@ -35,6 +35,25 @@ Consumers must treat `unknown` as non-authoritative. They should retry, fall
 back to the authoritative executor record, or escalate instead of inferring a
 successful result.
 
+Polling consumers should interpret these values at the transport boundary:
+
+| Status | Boundary meaning |
+| --- | --- |
+| `accepted` | The trusted boundary accepted the request and may not have assigned executor capacity yet. |
+| `queued` | The run is waiting for executor capacity or provider-local scheduling. |
+| `running` | The run is actively executing at the provider boundary. |
+| `cancelling` | A cancellation request was accepted and is still being applied. |
+| `cancelled` | The run has reached a stopped terminal observation; retrieve the final RunResult before treating the run as closed. |
+| `completed` | The run has reached a normal terminal observation; retrieve the final RunResult before consuming final details. |
+| `failed` | The run has reached a failed terminal observation; retrieve the final RunResult for diagnostics and evidence references. |
+| `blocked` | The run has reached a blocked terminal observation because a prerequisite is missing; retrieve the final RunResult for the blocking boundary and evidence references. |
+| `unknown` | The provider cannot currently make an authoritative state claim; this is not success, failure, or completion. |
+
+See
+[`integration/executor-operation-lifecycle.md`](integration/executor-operation-lifecycle.md)
+for the transport-level polling and terminal-state handoff rules that use this
+artifact.
+
 ## Optional Fields
 
 - `runId`: executor-local run id when the executor has assigned one.
@@ -54,9 +73,10 @@ details such as `completedAt`, `changeRequests`, `evidenceBundles`,
 `verification`, terminal `errors`, terminal `warnings`, or terminal `metrics`.
 
 When a snapshot reports `completed`, `failed`, `blocked`, or `cancelled`, it is
-only a status echo. Consumers retrieve final details via RunResult. RunResult is
-the terminal artifact that carries completion time, evidence references, change
-request references, verification summaries, diagnostics, and metrics.
+only a terminal snapshot status echo. Consumers retrieve final details via
+RunResult. RunResult is the terminal artifact that carries completion time,
+evidence references, change request references, verification summaries,
+diagnostics, and metrics.
 
 ## Connector Use
 

--- a/docs/integration/executor-operation-lifecycle.md
+++ b/docs/integration/executor-operation-lifecycle.md
@@ -79,6 +79,55 @@ consumer reports unsupported or unknown status rather than fabricating
 completion. When `status` is `unsupported`, consumers must not poll a different
 surface and present it as protocol status.
 
+## Polling And Terminal-State Rules
+
+Protocol polling is a consumer-owned polling loop over the provider's trusted
+`status` boundary. The protocol defines which artifacts and states cross that
+boundary; it does not define a shared scheduler, worker loop, retry engine,
+timer implementation, or runtime package.
+
+The polling cadence belongs to the consumer and the provider-specific
+capability contract. A boundary may publish a recommended minimum interval,
+backoff expectation, freshness limit, or maximum observation age. When no such
+contract is published, the consumer uses consumer-local orchestration and must
+not present its local retry timing as shared protocol behavior.
+
+Polling reads emit RunStatusSnapshot observations. `accepted`, `queued`,
+`running`, and `cancelling` are non-terminal progress observations. `unknown`
+is non-authoritative and must remain retry, fallback, or escalation input
+rather than success or failure. `cancelled`, `completed`, `failed`, and
+`blocked` are terminal snapshot status echo values: they indicate that polling
+has observed a terminal boundary state, but they do not carry final details.
+
+The terminal handoff from polling to result retrieval is explicit. After a
+terminal snapshot status echo, consumers retrieve the RunResult bound to the
+same RunRequest and authoritative run record. RunResult carries final status,
+completion time, verification, diagnostics, change request references, and
+evidence references. Consumers must not synthesize RunResult content from a
+snapshot, progress text, timeline entry, badge, timeout, or operator summary.
+
+In this contract, unsupported polling means the provider has no protocol status
+boundary for the exchange. Consumers may still use consumer-local orchestration
+to wait for a synchronous response, a terminal RunResult, or a provider-local
+callback, but they must report polling as unsupported and must not invent
+RunStatusSnapshot semantics from another surface.
+
+In this contract, partially supported polling means the boundary publishes a
+constrained subset: for example, only `queued` and `running`, only terminal
+echoes, no cancellation-related states, a maximum freshness window, or
+provider-specific minimum polling cadence. Observations outside that subset are
+unsupported or unknown unless the authoritative boundary explicitly extends the
+subset.
+
+A timeout is a consumer-local observation that a polling policy expired before
+a trusted terminal artifact was retrieved. A stale snapshot is an observation
+whose `observedAt` or provider freshness contract is too old to rely on. A
+no-progress report is a consumer-local report that repeated authoritative reads
+did not advance according to the published capability subset. These conditions
+are protocol-visible guidance for reporting and escalation, but they are not
+new RunStatusSnapshot statuses and do not imply `failed`, `blocked`,
+`cancelled`, `completed`, or any RunResult status.
+
 ## cancel lifecycle
 
 `cancel` requests cancellation for an already submitted run that is explicitly

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -311,4 +311,53 @@ describe("integration handoff documentation", () => {
       "integration/executor-operation-lifecycle.md"
     );
   });
+
+  it("documents polling and terminal-state handoff rules", () => {
+    const lifecycle = readDoc(
+      "docs/integration/executor-operation-lifecycle.md"
+    );
+    const statusSnapshot = readDoc("docs/EIP-0005-run-status-snapshot.md");
+    const runResult = readDoc("docs/EIP-0002-run-result.md");
+
+    for (const expected of [
+      "consumer-owned polling loop",
+      "polling cadence",
+      "terminal snapshot status echo",
+      "terminal handoff",
+      "timeout",
+      "stale",
+      "no-progress",
+      "unsupported polling",
+      "partially supported polling",
+      "consumer-local orchestration"
+    ]) {
+      expect(lifecycle).toContain(expected);
+    }
+
+    for (const expected of [
+      "accepted",
+      "queued",
+      "running",
+      "cancelling",
+      "cancelled",
+      "completed",
+      "failed",
+      "blocked",
+      "unknown"
+    ]) {
+      expect(statusSnapshot).toContain(expected);
+    }
+
+    expect(statusSnapshot).toMatch(/terminal snapshot status echo/i);
+    expect(statusSnapshot).toMatch(/retrieve.*RunResult/i);
+    expect(statusSnapshot).toContain(
+      "integration/executor-operation-lifecycle.md"
+    );
+    expect(runResult).toMatch(/terminal handoff/i);
+    expect(runResult).toMatch(/not valid RunResult statuses/i);
+    expect(runResult).toContain("integration/executor-operation-lifecycle.md");
+    expect(hasWorkstationHomePath(lifecycle + statusSnapshot + runResult)).toBe(
+      false
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- define consumer-owned polling loop expectations and terminal-state handoff rules
- clarify RunStatusSnapshot boundary status meanings and RunResult terminal handoff behavior
- add focused integration-docs regression coverage for polling and terminal-state guidance

## Verification
- npm test
- npm run check:public-fixtures
- npm run check:spec-boundary
- npm run check:fixtures

Closes #41

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Enhanced terminal state handoff guidance clarifying interaction between status snapshots and final completion results
* Added transport-boundary interpretation tables for all status values
* Documented polling protocol rules and terminal-state handling requirements to prevent incorrect result synthesis

## Tests

* Added integration test coverage for polling and terminal-state handoff rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->