### PR TITLE
PROTOCOL-034: Add capability variant fixtures

### DIFF
--- a/docs/integration/executor-transport-capabilities.md
+++ b/docs/integration/executor-transport-capabilities.md
@@ -108,6 +108,31 @@ capability cannot be represented with the current artifacts, route that as a
 protocol gap instead of adding local-only fields or extension keys that imply a
 general contract.
 
+## Conformance Fixture Examples
+
+Phase 3 capability variants are covered by public-safe examples under
+`fixtures/capability-variants/v1/valid/`. They are fixture-like conformance
+inputs for Loop and Flow consumers, not a new runtime, SDK, connector, OpenAPI
+endpoint, provider server, or schema family.
+
+Use these examples when checking capability matrices and provider-boundary
+evidence:
+
+| Example | Consumer conformance use |
+| --- | --- |
+| `fixtures/capability-variants/v1/valid/fully-supported-transport.json` | supported capability variant example for a boundary that advertises submit, status, cancel, fetchEvidence, polling, evidence references, and idempotency |
+| `fixtures/capability-variants/v1/valid/submit-only-no-polling.json` | partial capability variant example for submit-only or no-polling transports |
+| `fixtures/capability-variants/v1/valid/unsupported-cancel.json` | unsupported capability variant example for cancel requests that must remain blocked or routed |
+| `fixtures/capability-variants/v1/valid/evidence-unavailable.json` | evidence unavailable example for absent, inaccessible, expired, unauthorized, or unsupported evidence retrieval |
+| `fixtures/capability-variants/v1/valid/retryability-examples.json` | retryable transport failure example and non-retryable transport failure example for transport error mapping |
+
+Loop consumers should compare provider-boundary evidence with each example's
+`capabilitySummary` before treating an operation as available. Flow consumers
+should compare connector capability matrix rows with the same summaries. Both
+consumers should preserve the referenced RunRequest, RunStatusSnapshot,
+RunResult, and EvidenceBundleRef artifact families as copied contract fixtures
+and keep unsupported or partial operations fail closed.
+
 ## Drift Routing
 
 Loop and Flow consumers should report capability drift through

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -20,6 +20,9 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
   fixtures.
 - `run-status/v1/valid/` contains valid EIP-0005 RunStatusSnapshot fixtures.
 - `run-status/v1/invalid/` contains negative RunStatusSnapshot fixtures.
+- `capability-variants/v1/valid/` contains public-safe Phase 3 conformance
+  examples for executor transport capability variants. These examples are
+  fixture-like guidance, not a new EIP schema family.
 
 ## X-Gate 2 Loop-Flow Dry-Run Smoke
 
@@ -67,3 +70,35 @@ Downstream X-Gate 2 issues should point back to these fixture expectations:
 
 - [Ensen-flow X-Gate 2 CLI-backed smoke issue](https://github.com/TommyKammy/Ensen-flow/issues/37)
 - [Ensen-loop X-Gate 2 dry-run output issue](https://github.com/TommyKammy/Ensen-loop/issues/35)
+
+## Phase 3 Capability Variant Examples
+
+Phase 3 adds public-safe conformance examples for the executor capability model,
+lifecycle rules, polling behavior, evidence retrieval, and transport
+retryability guidance. They are intentionally transport-neutral JSON examples:
+they do not imply that Ensen-protocol provides a runtime server, SDK,
+connector, OpenAPI endpoint, queue, or provider implementation.
+
+Use these examples as copied or vendored conformance inputs:
+
+| Example | Covered behavior |
+| --- | --- |
+| `fixtures/capability-variants/v1/valid/fully-supported-transport.json` | supported capability variant example for submit, status, cancel, fetchEvidence, polling, evidence references, and idempotency |
+| `fixtures/capability-variants/v1/valid/submit-only-no-polling.json` | partial capability variant example for submit-only or no-polling transports |
+| `fixtures/capability-variants/v1/valid/unsupported-cancel.json` | unsupported capability variant example for cancel requests that must not be inferred as successful |
+| `fixtures/capability-variants/v1/valid/evidence-unavailable.json` | evidence unavailable example for absent, inaccessible, expired, or unsupported evidence retrieval |
+| `fixtures/capability-variants/v1/valid/retryability-examples.json` | retryable transport failure example and non-retryable transport failure example |
+
+Loop and Flow consumers should use the examples as conformance check rows:
+
+- compare each consumer capability matrix or provider boundary against
+  `capabilitySummary`;
+- verify unsupported and out-of-subset operations stay blocked, rejected,
+  unknown, or routed instead of being coerced into success;
+- verify retryable transport failures preserve the same authoritative scope and
+  idempotency binding;
+- verify non-retryable validation, unsupported capability, or unavailable
+  evidence cases do not produce fabricated RunStatusSnapshot or RunResult
+  success;
+- keep local commands and evidence references repo-relative or placeholder-based
+  when copying the examples into consumer repositories.

--- a/fixtures/capability-variants/v1/valid/evidence-unavailable.json
+++ b/fixtures/capability-variants/v1/valid/evidence-unavailable.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "eip.capability-variant.example.v1",
+  "variant": "evidence-unavailable",
+  "description": "evidence unavailable example for a synthetic boundary that can finish a run while evidence retrieval is absent or inaccessible.",
+  "protocolSnapshot": {
+    "tag": "v0.1.0",
+    "commit": "43fa3e7",
+    "issue": "https://github.com/TommyKammy/Ensen-protocol/issues/43"
+  },
+  "runtimeBoundary": "none",
+  "boundaryRef": "<executor-boundary>",
+  "artifactRefs": [
+    "fixtures/run-result/v1/valid/blocked-result.json",
+    "fixtures/evidence-bundle-ref/v1/valid/local-path.json"
+  ],
+  "capabilitySummary": {
+    "submit": "required baseline",
+    "status": "optional",
+    "cancel": "optional",
+    "fetchEvidence": "unsupported",
+    "polling support": "optional",
+    "evidence reference support": "partial",
+    "idempotency expectation": "required baseline"
+  },
+  "expectedConformance": [
+    "required evidence that is absent, expired, unauthorized, or outside supported roots keeps the handoff blocked",
+    "evidence absence must not change the authoritative run status by itself",
+    "examples preserve placeholders such as <evidence-root> instead of local workstation paths"
+  ],
+  "conformanceUse": "Loop and Flow consumers can use this example to keep evidence retrieval absence separate from runtime execution success."
+}

--- a/fixtures/capability-variants/v1/valid/fully-supported-transport.json
+++ b/fixtures/capability-variants/v1/valid/fully-supported-transport.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": "eip.capability-variant.example.v1",
+  "variant": "fully-supported-transport",
+  "description": "supported capability variant example for a synthetic executor boundary that advertises every Phase 3 operation.",
+  "protocolSnapshot": {
+    "tag": "v0.1.0",
+    "commit": "43fa3e7",
+    "issue": "https://github.com/TommyKammy/Ensen-protocol/issues/43"
+  },
+  "runtimeBoundary": "none",
+  "boundaryRef": "<executor-boundary>",
+  "artifactRefs": [
+    "fixtures/run-request/v1/valid/github-issue-request.json",
+    "fixtures/run-status/v1/valid/running-snapshot.json",
+    "fixtures/run-status/v1/valid/completed-snapshot.json",
+    "fixtures/run-result/v1/valid/succeeded-result.json",
+    "fixtures/evidence-bundle-ref/v1/valid/file-uri.json"
+  ],
+  "capabilitySummary": {
+    "submit": "required baseline",
+    "status": "optional",
+    "cancel": "optional",
+    "fetchEvidence": "optional",
+    "polling support": "optional",
+    "evidence reference support": "optional",
+    "idempotency expectation": "required baseline"
+  },
+  "expectedConformance": [
+    "submit accepts a RunRequest only at a trusted executor boundary",
+    "polling reads RunStatusSnapshot observations from the authoritative run binding",
+    "terminal handoff retrieves RunResult instead of synthesizing it from polling text",
+    "EvidenceBundleRef remains a reference and does not embed evidence payloads"
+  ],
+  "conformanceUse": "Loop and Flow consumers can use this example as the fully supported comparison row when checking copied Phase 3 fixtures."
+}

--- a/fixtures/capability-variants/v1/valid/retryability-examples.json
+++ b/fixtures/capability-variants/v1/valid/retryability-examples.json
@@ -1,0 +1,47 @@
+{
+  "schemaVersion": "eip.capability-variant.example.v1",
+  "variant": "retryability-examples",
+  "description": "retryable transport failure example and non-retryable transport failure example for synthetic Phase 3 capability checks.",
+  "protocolSnapshot": {
+    "tag": "v0.1.0",
+    "commit": "43fa3e7",
+    "issue": "https://github.com/TommyKammy/Ensen-protocol/issues/43"
+  },
+  "runtimeBoundary": "none",
+  "boundaryRef": "<executor-boundary>",
+  "artifactRefs": [
+    "fixtures/run-request/v1/valid/github-issue-request.json",
+    "fixtures/run-status/v1/valid/accepted-snapshot.json",
+    "fixtures/run-result/v1/valid/blocked-result.json"
+  ],
+  "capabilitySummary": {
+    "submit": "required baseline",
+    "status": "partial",
+    "cancel": "unsupported",
+    "fetchEvidence": "unsupported",
+    "polling support": "partial",
+    "evidence reference support": "partial",
+    "idempotency expectation": "required baseline"
+  },
+  "cases": [
+    {
+      "name": "transient transport failure",
+      "operation": "status",
+      "retryability": "retryable",
+      "expectedMapping": "preserve the prior authoritative snapshot and retry only as consumer-local policy"
+    },
+    {
+      "name": "unsupported capability",
+      "operation": "cancel",
+      "retryability": "not retryable",
+      "expectedMapping": "route or block the unsupported operation without marking the run cancelled"
+    },
+    {
+      "name": "validation failure",
+      "operation": "submit",
+      "retryability": "not retryable",
+      "expectedMapping": "block until the artifact is corrected"
+    }
+  ],
+  "conformanceUse": "Loop and Flow consumers can use this example to separate retryable transport failures from non-retryable capability or validation failures."
+}

--- a/fixtures/capability-variants/v1/valid/submit-only-no-polling.json
+++ b/fixtures/capability-variants/v1/valid/submit-only-no-polling.json
@@ -1,0 +1,31 @@
+{
+  "schemaVersion": "eip.capability-variant.example.v1",
+  "variant": "submit-only-no-polling",
+  "description": "partial capability variant example for a synthetic boundary that accepts submission but does not publish protocol polling.",
+  "protocolSnapshot": {
+    "tag": "v0.1.0",
+    "commit": "43fa3e7",
+    "issue": "https://github.com/TommyKammy/Ensen-protocol/issues/43"
+  },
+  "runtimeBoundary": "none",
+  "boundaryRef": "<executor-boundary>",
+  "artifactRefs": [
+    "fixtures/run-request/v1/valid/manual-request.json",
+    "fixtures/run-result/v1/valid/succeeded-result.json"
+  ],
+  "capabilitySummary": {
+    "submit": "required baseline",
+    "status": "unsupported",
+    "cancel": "unsupported",
+    "fetchEvidence": "unsupported",
+    "polling support": "unsupported",
+    "evidence reference support": "partial",
+    "idempotency expectation": "required baseline"
+  },
+  "expectedConformance": [
+    "consumer-local waiting may exist but must not be presented as RunStatusSnapshot polling",
+    "terminal RunResult must remain bound to the submitted RunRequest",
+    "unsupported polling must not fabricate completed, failed, blocked, or cancelled snapshots"
+  ],
+  "conformanceUse": "Loop and Flow consumers can use this example to verify submit-only transports stay explicit about unsupported polling."
+}

--- a/fixtures/capability-variants/v1/valid/unsupported-cancel.json
+++ b/fixtures/capability-variants/v1/valid/unsupported-cancel.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": "eip.capability-variant.example.v1",
+  "variant": "unsupported-cancel",
+  "description": "unsupported capability variant example for a synthetic boundary that reports cancellation as unavailable.",
+  "protocolSnapshot": {
+    "tag": "v0.1.0",
+    "commit": "43fa3e7",
+    "issue": "https://github.com/TommyKammy/Ensen-protocol/issues/43"
+  },
+  "runtimeBoundary": "none",
+  "boundaryRef": "<executor-boundary>",
+  "artifactRefs": [
+    "fixtures/run-request/v1/valid/github-issue-request.json",
+    "fixtures/run-status/v1/valid/running-snapshot.json",
+    "fixtures/run-result/v1/valid/blocked-result.json"
+  ],
+  "capabilitySummary": {
+    "submit": "required baseline",
+    "status": "optional",
+    "cancel": "unsupported",
+    "fetchEvidence": "partial",
+    "polling support": "partial",
+    "evidence reference support": "partial",
+    "idempotency expectation": "required baseline"
+  },
+  "expectedConformance": [
+    "cancel requests outside the published support set leave the authoritative run unchanged",
+    "consumers report unsupported cancellation instead of marking the run cancelled by inference",
+    "status and terminal result remain anchored to the authoritative run record"
+  ],
+  "conformanceUse": "Loop and Flow consumers can use this example to check that unsupported cancel paths fail closed."
+}

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "../test-support/assertions.js";
@@ -12,6 +12,10 @@ const workstationHomePathFragments = [
 
 function readDoc(relativePath: string): string {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(readDoc(relativePath)) as T;
 }
 
 function hasWorkstationHomePath(content: string): boolean {
@@ -412,5 +416,75 @@ describe("integration handoff documentation", () => {
     expect(hasWorkstationHomePath(lifecycle + statusSnapshot + runResult)).toBe(
       false
     );
+  });
+
+  it("links Phase 3 capability variant examples from the capability guidance", () => {
+    const capabilityGuide = readDoc(
+      "docs/integration/executor-transport-capabilities.md"
+    );
+    const lifecycle = readDoc(
+      "docs/integration/executor-operation-lifecycle.md"
+    );
+    const fixturesReadme = readDoc("fixtures/README.md");
+    const examplePaths = [
+      "fixtures/capability-variants/v1/valid/fully-supported-transport.json",
+      "fixtures/capability-variants/v1/valid/submit-only-no-polling.json",
+      "fixtures/capability-variants/v1/valid/unsupported-cancel.json",
+      "fixtures/capability-variants/v1/valid/evidence-unavailable.json",
+      "fixtures/capability-variants/v1/valid/retryability-examples.json"
+    ];
+
+    for (const examplePath of examplePaths) {
+      expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
+      expect(capabilityGuide).toContain(examplePath);
+      expect(fixturesReadme).toContain(examplePath);
+    }
+
+    const examples = examplePaths.map((examplePath) =>
+      readJson<{
+        variant: string;
+        capabilitySummary: Record<string, string>;
+        conformanceUse: string;
+        runtimeBoundary: string;
+      }>(examplePath)
+    );
+
+    expect(examples.map((example) => example.variant)).toEqual([
+      "fully-supported-transport",
+      "submit-only-no-polling",
+      "unsupported-cancel",
+      "evidence-unavailable",
+      "retryability-examples"
+    ]);
+    expect(examples.map((example) => example.capabilitySummary.status)).toContain(
+      "unsupported"
+    );
+    expect(examples.map((example) => example.capabilitySummary.cancel)).toContain(
+      "unsupported"
+    );
+    expect(examples.map((example) => example.capabilitySummary.fetchEvidence)).toContain(
+      "unsupported"
+    );
+    expect(
+      examples.some((example) =>
+        Object.values(example.capabilitySummary).includes("partial")
+      )
+    ).toBe(true);
+
+    for (const example of examples) {
+      expect(example.runtimeBoundary).toBe("none");
+      expect(example.conformanceUse).toMatch(/Loop|Flow/);
+    }
+
+    for (const expected of [
+      "supported capability variant example",
+      "partial capability variant example",
+      "unsupported capability variant example",
+      "evidence unavailable example",
+      "retryable transport failure example",
+      "non-retryable transport failure example"
+    ]) {
+      expect(capabilityGuide + lifecycle + fixturesReadme).toContain(expected);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add public-safe Phase 3 capability variant examples for supported, partial, unsupported, evidence-unavailable, and retryability cases
- link the examples from the executor transport capability guide and fixtures README for Loop/Flow conformance use
- add a regression test that keeps the capability examples discoverable

## Verification
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:schema-ids
- npm run check:spec-boundary

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Phase 3 executor transport capability variant conformance guidance with fixture examples for various scenarios. New documentation describes how consumers should validate and compare transport capabilities against conformance fixtures covering fully-supported, submit-only, evidence-unavailable, unsupported operations, and retry behaviors.

* **Tests**
  * Added integration tests validating Phase 3 capability variant fixtures and documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->