### PR TITLE
PROTOCOL-X3B-001: Add Track B classification profile

### DIFF
--- a/docs/EIP-0000-common-types.md
+++ b/docs/EIP-0000-common-types.md
@@ -56,6 +56,19 @@ artifact. It requires an explicit sourceId and sourceType.
 WorkItemRef, ChangeRequestRef, and EvidenceBundleRef link to their respective
 protocol records by explicit reference id fields.
 
+## Data Classification
+
+DataClassification labels the handling boundary for fixture and production
+message data. v1 values are `public`, `internal`, `confidential`,
+`customer-confidential`, `regulated`, and `restricted`.
+
+Track B customer / regulated profile guidance lives in
+`docs/integration/customer-regulated-data-classification-profile.md`. Customer
+/ regulated references and evidence artifacts require an explicit
+classification value before handling. Missing or unknown classification must
+fail closed instead of being inferred from path shape, repository naming,
+operator notes, or nearby metadata.
+
 ErrorInfo carries structured failure information. Error codes are stable,
 uppercase protocol tokens. Messages are diagnostic text and are not stable
 machine contracts.

--- a/docs/EIP-0003-audit-event.md
+++ b/docs/EIP-0003-audit-event.md
@@ -76,3 +76,8 @@ Loop and Flow Track A artifact hygiene events should follow
 `docs/integration/operational-evidence-profile.md` for public fixture-safe
 labels, local confidential reference handling, producer metadata, retention
 hint, and checksum facts.
+
+Track B customer / regulated events should follow
+`docs/integration/customer-regulated-data-classification-profile.md` before
+customer / regulated evidence production, validation, rejection, redaction, or
+handoff facts are accepted. Missing or unknown classification must fail closed.

--- a/docs/EIP-0004-evidence-bundle-ref.md
+++ b/docs/EIP-0004-evidence-bundle-ref.md
@@ -67,3 +67,11 @@ For Loop and Flow Track A artifact hygiene guidance, use
 fixture-safe evidence references from local confidential references and to
 record data classification, checksum, producer metadata, and retention hint
 expectations.
+
+For Track B customer / regulated evidence guidance, use
+`docs/integration/customer-regulated-data-classification-profile.md`.
+EvidenceBundleRef references to customer evidence, regulated evidence, or
+customer-system-derived output require an explicit classification before
+handling. Missing or unknown classification must fail closed instead of being
+inferred from URI shape, repository naming, tenant hints, or operator-facing
+summaries.

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,8 @@ Start here:
   mapping expectations.
 - `docs/integration/operational-evidence-profile.md` defines the operational
   evidence profile for Loop and Flow Track A artifact hygiene checks.
+- `docs/integration/customer-regulated-data-classification-profile.md` defines the
+  Track B customer / regulated data classification profile.
 - `integration/cross-repo-change-policy.md` defines the protocol-first
   cross-repo change process.
 - `security.md` defines security posture for protocol artifacts.

--- a/docs/data-classification.md
+++ b/docs/data-classification.md
@@ -9,10 +9,39 @@ apply appropriate handling rules.
   conformance tests.
 - `internal`: intended for routine internal protocol operations, but not for
   public fixtures.
-- `confidential`: contains business-sensitive or user-sensitive production
-  message data.
-- `restricted`: contains highly sensitive production message data that requires
-  the strictest supported handling.
+- `confidential`: contains business-sensitive or user-sensitive non-public
+  production message data that is not specifically customer-owned or regulated.
+- `customer-confidential`: contains customer-owned, customer-identifying, or
+  customer-provided information that must stay in the owning customer /
+  tenant evidence boundary.
+- `regulated`: contains data or evidence subject to regulated handling,
+  validation, retention, privacy, electronic record, or domain-specific control
+  requirements.
+- `restricted`: legacy high-sensitivity label for existing v1 artifacts that
+  need stricter handling than `confidential`. New Track B customer / regulated
+  evidence should use `customer-confidential` or `regulated` when those terms
+  describe the boundary.
+
+## Track B Customer / Regulated Profile
+
+Track B customer / regulated profile is the short name for the required
+classification profile used by customer / regulated evidence handoffs.
+
+The Track B customer / regulated profile is the required classification profile
+for protocol artifacts that reference customer-controlled systems, customer
+evidence, regulated evidence, regulated workflow facts, or customer / regulated
+AuditEvent and EvidenceBundleRef surfaces.
+
+Classification required means the producer must emit one explicit
+classification value before a customer / regulated reference or evidence
+artifact can be handled as Track B evidence. The value must be selected from
+the common `DataClassification` vocabulary above. The fail-closed trigger is
+missing or unknown classification: consumers should reject, block, quarantine,
+or route the artifact for an explicit protocol or consumer follow-up instead of
+guessing that a nearby label is acceptable.
+
+The detailed handoff profile is
+`docs/integration/customer-regulated-data-classification-profile.md`.
 
 ## Fixture Data
 

--- a/docs/integration/customer-regulated-data-classification-profile.md
+++ b/docs/integration/customer-regulated-data-classification-profile.md
@@ -1,0 +1,118 @@
+# Track B Customer / Regulated Data Classification Profile
+
+The Track B customer / regulated data classification profile defines the
+shared protocol vocabulary that Loop, Flow, Pharma, and future consumers can
+cite before customer or regulated evidence work begins.
+
+This profile is contract text only. It preserves the Ensen development charter:
+protocol over shared implementation, bounded execution, evidence before
+authority, and no premature compliance claims. It does not add a runtime
+validator package, connector, SDK, ERPNext integration, customer data access, or
+compliance guarantee.
+
+## Vocabulary
+
+Use the common `DataClassification` values from
+`schemas/eip.common.v1.schema.json`:
+
+| Value | Boundary |
+| --- | --- |
+| `public` | Synthetic fixture, example, documentation, or conformance data that is safe to publish. |
+| `internal` | Routine non-public protocol or operator evidence that is not customer-owned and not regulated. |
+| `confidential` | Sensitive business or user production facts that are not specifically customer-owned or regulated. |
+| `customer-confidential` | Customer-owned, customer-identifying, customer-provided, or customer-system-derived information. |
+| `regulated` | Evidence or data subject to regulated handling, privacy, retention, validation, electronic record, or domain-specific controls. |
+
+`restricted` remains a legacy high-sensitivity v1 label, but Track B customer /
+regulated references should use `customer-confidential` or `regulated` when
+those boundaries apply.
+
+## When Classification Required
+
+classification required is the Track B rule that a producer must emit an
+explicit profile value before customer / regulated evidence handling begins.
+
+Classification required applies before any Track B customer / regulated
+reference or evidence artifact is accepted, copied, exported, or used as
+handoff evidence.
+
+Classification is required for:
+
+- EvidenceBundleRef artifacts that point at customer evidence, regulated
+  evidence, customer system output, or regulated workflow evidence;
+- AuditEvent payloads that describe customer / regulated evidence production,
+  validation, rejection, redaction, retention, or handoff;
+- operational evidence profile records that cross from Track A synthetic or
+  owner-controlled evidence into Track B customer / regulated handling;
+- fixture-like examples that describe customer / regulated behavior, even when
+  the checked-in values are synthetic and `public`;
+- protocol snapshot records that name customer / regulated fixture families,
+  profile documents, or consumer-side conformance evidence.
+
+The fail-closed trigger is missing or unknown classification. Consumers should
+reject, block, quarantine, or route an explicit follow-up when classification is
+absent, not in the common vocabulary, inconsistent with the evidence boundary,
+or only implied by names, paths, comments, issue text, operator summaries,
+tenant hints, repository names, or nearby metadata.
+
+In short: missing classification and unknown classification must fail closed.
+
+## Artifact Mapping
+
+EvidenceBundleRef should carry only a stable reference, checksum when
+available, content type, and bounded public metadata. It must not embed
+customer data, regulated data, private repository details, raw secrets, or
+evidence bodies. For Track B, the reference handling boundary must have an
+explicit classification before the reference is used.
+
+AuditEvent should record append-only facts about classification, production,
+validation, rejection, redaction, and handoff. AuditEvent payloads may include
+`dataClassification`, redacted reference kind, producer boundary, checksum
+presence, and follow-up routing. They must not infer customer, tenant,
+repository, account, issue, environment, authorization, or regulated status from
+path shape or operator-facing summaries.
+
+The Track A `docs/integration/operational-evidence-profile.md` remains the
+public fixture-safe artifact hygiene profile. Track B uses the same public
+fixture safety rules, then adds required customer / regulated classification
+before any customer / regulated references are handled.
+
+The protocol snapshot policy in `docs/protocol-snapshot-policy.md` should name
+this profile when a copied snapshot includes Track B customer / regulated
+classification docs, fixtures, or downstream conformance evidence.
+
+## Public Fixture Safety
+
+Public examples for this profile must remain synthetic and publishable. They
+must use `public` classification and must not contain customer data, regulated
+data, raw secrets, credentials, access tokens, private repository details,
+workstation-local absolute paths, live ERPNext write-back targets, electronic
+signature records, batch release records, or final disposition records.
+
+Use placeholders such as `<customer-ref>`, `<regulated-evidence-ref>`,
+`<credential-ref>`, `<repository-ref>`, `<evidence-root>`, and
+`<supervisor-config-path>` when a profile example needs to name a boundary
+without exposing local or private state.
+
+The public-safe conformance example lives at
+`fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json`.
+It is fixture-like guidance, not a new EIP schema family.
+
+## Track B Non-Claims
+
+Track B reached means the protocol contract has enough vocabulary for downstream
+customer / regulated evidence handling work to begin.
+
+- not production-ready
+- not a validated system
+- not a compliance guarantee
+- not automatic quality decision support
+- not live ERPNext write-back
+- not electronic signature
+- not batch release
+- not final disposition approval
+
+Loop, Flow, Pharma, and future consumers remain responsible for runtime
+authorization, customer boundary enforcement, regulated workflow controls,
+credential handling, storage, retention, audit storage, validation evidence,
+and any domain-specific compliance work.

--- a/docs/integration/operational-evidence-profile.md
+++ b/docs/integration/operational-evidence-profile.md
@@ -99,6 +99,12 @@ authorization context, or boundary signals are missing, malformed, or only
 partially trusted. A syntactically valid EvidenceBundleRef or AuditEvent is not
 proof that the referenced evidence is trusted or authorized.
 
+Track B customer / regulated evidence handling builds on this profile through
+`docs/integration/customer-regulated-data-classification-profile.md`. Track A
+does not permit customer repo input, regulated data, live ERPNext write-back,
+electronic signatures, batch release, final disposition approval, or compliance
+claims.
+
 ## Conformance Example
 
 The public conformance example lives at

--- a/docs/protocol-snapshot-policy.md
+++ b/docs/protocol-snapshot-policy.md
@@ -34,6 +34,10 @@ Each consumer snapshot record should include:
 - operational evidence profile: the
   `docs/integration/operational-evidence-profile.md` guidance used when the
   copied snapshot includes Track A artifact hygiene examples;
+- customer / regulated classification profile: the
+  `docs/integration/customer-regulated-data-classification-profile.md` guidance
+  used when the copied snapshot includes Track B customer / regulated
+  classification evidence;
 - consumer owner: the local consumer test, task, or adapter boundary that reads
   the copied snapshot;
 - unsupported EIP major version evidence: sanitized evidence naming the

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -27,6 +27,10 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
   artifact hygiene examples for
   `docs/integration/operational-evidence-profile.md`. These examples are
   fixture-like guidance, not a new EIP schema family.
+- `customer-regulated-data-classification/v1/valid/` contains public-safe
+  Track B classification profile examples for
+  `docs/integration/customer-regulated-data-classification-profile.md`. These
+  examples are fixture-like guidance, not a new EIP schema family.
 
 ## X-Gate 2 Loop-Flow Dry-Run Smoke
 
@@ -106,3 +110,20 @@ Loop and Flow consumers should use the examples as conformance check rows:
   success;
 - keep local commands and evidence references repo-relative or placeholder-based
   when copying the examples into consumer repositories.
+
+## Track B Customer / Regulated Classification Example
+
+Track B adds public-safe classification profile examples for customer /
+regulated evidence planning. The examples do not contain customer data,
+regulated data, raw secrets, credentials, private repository details, or
+workstation-local absolute paths.
+
+Use this example as copied or vendored conformance input:
+
+| Example | Covered behavior |
+| --- | --- |
+| `fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json` | public-safe Track B classification vocabulary, classification-required surfaces, fail-closed handling, and non-claims |
+
+Loop, Flow, and Pharma consumers should use the example to verify that customer
+/ regulated references require explicit classification and that missing or
+unknown classification stays blocked or routed instead of inferred.

--- a/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
+++ b/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
@@ -1,0 +1,42 @@
+{
+  "profile": "track-b-classification.v1",
+  "scenario": "public-safe-track-b-profile",
+  "track": "X-Gate 3 Track B",
+  "boundary": "customer / regulated evidence planning",
+  "exampleClassification": "public",
+  "classificationTerms": [
+    "public",
+    "internal",
+    "confidential",
+    "customer-confidential",
+    "regulated"
+  ],
+  "classificationRequiredFor": [
+    "EvidenceBundleRef customer evidence references",
+    "AuditEvent regulated evidence handling facts",
+    "operational evidence profile handoff records",
+    "protocol snapshot records that include Track B classification evidence"
+  ],
+  "failClosedPolicy": {
+    "missingClassification": "reject or route explicit follow-up",
+    "unknownClassification": "reject or route explicit follow-up",
+    "inferredClassification": "do not infer from path shape, repository naming, or operator summaries"
+  },
+  "publicFixtureSafety": {
+    "containsCustomerData": false,
+    "containsRegulatedData": false,
+    "containsSecrets": false,
+    "containsPrivateRepositoryDetails": false,
+    "containsWorkstationLocalAbsolutePath": false,
+    "placeholderEvidenceRoot": "<evidence-root>/track-b/public-safe-example.json"
+  },
+  "nonClaims": [
+    "not production-ready",
+    "not a validated system",
+    "not a compliance guarantee",
+    "not live ERPNext write-back",
+    "not electronic signature",
+    "not batch release",
+    "not final disposition approval"
+  ]
+}

--- a/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
+++ b/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
@@ -12,7 +12,7 @@
     "regulated"
   ],
   "classificationRequiredFor": [
-    "EvidenceBundleRef customer evidence references",
+    "EvidenceBundleRef Track B evidence references",
     "AuditEvent regulated evidence handling facts",
     "operational evidence profile handoff records",
     "protocol snapshot records that include Track B classification evidence"

--- a/package-lock.json
+++ b/package-lock.json
@@ -533,9 +533,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/schemas/eip.common.v1.schema.json
+++ b/schemas/eip.common.v1.schema.json
@@ -201,8 +201,15 @@
     },
     "DataClassification": {
       "type": "string",
-      "description": "Classification label for fixture and production data handling.",
-      "enum": ["public", "internal", "confidential", "restricted"]
+      "description": "Classification label for fixture and production data handling. Track B customer and regulated evidence uses customer-confidential or regulated when those boundaries apply.",
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "customer-confidential",
+        "regulated",
+        "restricted"
+      ]
     }
   }
 }

--- a/scripts/check-public-fixtures.ts
+++ b/scripts/check-public-fixtures.ts
@@ -23,7 +23,7 @@ const likelySecretValuePatterns: Array<[RegExp, string]> = [
 
 const sensitiveKeyPattern = /(?:^|[-_.])(?:secret|token|password|passwd|privateKey|apiKey|accessKey)(?:$|[-_.])/i;
 const customerSpecificValuePattern =
-  /\b(?:acme|globex|initech|customer[_-][a-z0-9-]+|tenant[_ -]?[a-z0-9-]+)\b/i;
+  /\b(?:acme|globex|initech|customer[_ -]?[a-z0-9-]+|tenant[_ -]?[a-z0-9-]+)\b/i;
 const workstationPathPattern = /(?:\/Users\/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)/;
 const classificationKeyPattern = /^(?:dataClassification|classification)$/;
 const publicClassificationValue = "public";

--- a/scripts/check-public-fixtures.ts
+++ b/scripts/check-public-fixtures.ts
@@ -23,8 +23,18 @@ const likelySecretValuePatterns: Array<[RegExp, string]> = [
 
 const sensitiveKeyPattern = /(?:^|[-_.])(?:secret|token|password|passwd|privateKey|apiKey|accessKey)(?:$|[-_.])/i;
 const customerSpecificValuePattern =
-  /\b(?:acme|globex|initech|customer[_ -]?[a-z0-9-]+|tenant[_ -]?[a-z0-9-]+)\b/i;
+  /\b(?:acme|globex|initech|customer[_-][a-z0-9-]+|tenant[_ -]?[a-z0-9-]+)\b/i;
 const workstationPathPattern = /(?:\/Users\/[^/\s]+|[A-Za-z]:\\Users\\[^\\\s]+)/;
+const classificationKeyPattern = /^(?:dataClassification|classification)$/;
+const publicClassificationValue = "public";
+const classificationVocabularyValues = new Set([
+  "public",
+  "internal",
+  "confidential",
+  "customer-confidential",
+  "regulated",
+  "restricted"
+]);
 
 function repoRoot(): string {
   return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -78,13 +88,28 @@ function inspectValue(
   }
 
   if (typeof value === "string") {
+    if (
+      key &&
+      classificationKeyPattern.test(key) &&
+      value !== publicClassificationValue
+    ) {
+      findings.push({
+        filePath,
+        pointer,
+        reason: `non-public fixture classification: ${value}`
+      });
+    }
+
     for (const [pattern, reason] of likelySecretValuePatterns) {
       if (pattern.test(value)) {
         findings.push({ filePath, pointer, reason });
       }
     }
 
-    if (customerSpecificValuePattern.test(value)) {
+    if (
+      customerSpecificValuePattern.test(value) &&
+      !classificationVocabularyValues.has(value)
+    ) {
       findings.push({ filePath, pointer, reason: "customer-specific value" });
     }
 

--- a/test/common-schema.test.ts
+++ b/test/common-schema.test.ts
@@ -125,6 +125,23 @@ describe("EIP-0000 common schema", () => {
     }
   );
 
+  it.each(["public", "internal", "confidential", "customer-confidential", "regulated"])(
+    "accepts Track B customer and regulated classification profile value: %s",
+    (classification) => {
+      expect(
+        validate(commonEnvelope({ classification })),
+        JSON.stringify(validate.errors, null, 2)
+      ).toBe(true);
+    }
+  );
+
+  it.each(["", "unknown", "customer", "regulated-data"])(
+    "rejects missing or unknown classification profile value: %s",
+    (classification) => {
+      expect(validate(commonEnvelope({ classification }))).toBe(false);
+    }
+  );
+
   it.each(["service", "workflow-engine", "apiClient", ""])(
     "rejects malformed or non-design ActorRef actorType: %s",
     (actorType) => {
@@ -178,6 +195,8 @@ describe("EIP-0000 common docs", () => {
     expect(commonTypes).toContain("artifact-specific primary ID aliases");
     expect(dataClassification).toContain("public fixture data");
     expect(dataClassification).toContain("production message data");
+    expect(dataClassification).toContain("Track B customer / regulated profile");
+    expect(dataClassification).toContain("missing or unknown classification");
     expect(idempotency).toContain("CorrelationId");
   });
 });

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -540,4 +540,64 @@ describe("integration handoff documentation", () => {
     expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
     expect(hasWorkstationHomePath(profile)).toBe(false);
   });
+
+  it("documents the Track B customer and regulated data classification profile", () => {
+    const profilePath =
+      "docs/integration/customer-regulated-data-classification-profile.md";
+    const examplePath =
+      "fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json";
+    const profile = readDoc(profilePath);
+    const docsIndex = readDoc("docs/README.md");
+    const dataClassification = readDoc("docs/data-classification.md");
+    const evidenceRef = readDoc("docs/EIP-0004-evidence-bundle-ref.md");
+    const auditEvent = readDoc("docs/EIP-0003-audit-event.md");
+    const operationalProfile = readDoc(
+      "docs/integration/operational-evidence-profile.md"
+    );
+    const snapshotPolicy = readDoc("docs/protocol-snapshot-policy.md");
+    const fixturesReadme = readDoc("fixtures/README.md");
+
+    for (const expected of [
+      "Track B customer / regulated data classification profile",
+      "public",
+      "internal",
+      "confidential",
+      "customer-confidential",
+      "regulated",
+      "classification required",
+      "customer / regulated references",
+      "missing or unknown classification",
+      "fail closed",
+      "EvidenceBundleRef",
+      "AuditEvent",
+      "operational-evidence-profile.md",
+      "fixture safety",
+      "snapshot policy",
+      "not production-ready",
+      "not a validated system",
+      "not a compliance guarantee",
+      "not live ERPNext write-back",
+      "not electronic signature",
+      "not batch release",
+      "not final disposition approval",
+      examplePath
+    ]) {
+      expect(profile).toContain(expected);
+    }
+
+    for (const linkedDoc of [
+      docsIndex,
+      dataClassification,
+      evidenceRef,
+      auditEvent,
+      operationalProfile,
+      snapshotPolicy,
+      fixturesReadme
+    ]) {
+      expect(linkedDoc).toContain(profilePath);
+    }
+
+    expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
+    expect(hasWorkstationHomePath(profile)).toBe(false);
+  });
 });

--- a/test/public-fixtures.test.ts
+++ b/test/public-fixtures.test.ts
@@ -69,6 +69,31 @@ describe("public fixture safety", () => {
     );
   });
 
+  it("rejects customer identifiers with optional separators", () => {
+    withTempFixture(
+      {
+        schemaVersion: "fixture.test",
+        references: [
+          "customerbeta",
+          "customer beta",
+          "customer-beta",
+          "customer_beta",
+          "tenantbeta",
+          "tenant beta"
+        ]
+      },
+      (filePath) => {
+        const result = checkPublicFixtures([filePath]);
+        const customerSpecificFindings = result.findings.filter(
+          (finding) => finding.reason === "customer-specific value"
+        );
+
+        expect(result.ok).toBe(false);
+        expect(customerSpecificFindings.length).toBe(6);
+      }
+    );
+  });
+
   it("rejects non-public data classification in publishable fixtures", () => {
     withTempFixture(
       {

--- a/test/public-fixtures.test.ts
+++ b/test/public-fixtures.test.ts
@@ -69,6 +69,29 @@ describe("public fixture safety", () => {
     );
   });
 
+  it("rejects non-public data classification in publishable fixtures", () => {
+    withTempFixture(
+      {
+        schemaVersion: "fixture.test",
+        dataClassification: "regulated",
+        nested: {
+          classification: "customer-confidential"
+        }
+      },
+      (filePath) => {
+        const result = checkPublicFixtures([filePath]);
+
+        expect(result.ok).toBe(false);
+        expect(result.findings.map((finding) => finding.reason)).toEqual(
+          expect.arrayContaining([
+            "non-public fixture classification: regulated",
+            "non-public fixture classification: customer-confidential"
+          ])
+        );
+      }
+    );
+  });
+
   it("rejects fixture safety negative examples when checked directly", () => {
     const result = checkPublicFixtures([
       path.join(repoRoot, "fixtures/run-request/v1/invalid/raw-secret.json"),


### PR DESCRIPTION
## Summary
- define the Track B customer / regulated data classification profile for Protocol artifacts
- extend common classification vocabulary with `customer-confidential` and `regulated`
- add public-safe fixture guidance and fail-closed fixture checks for non-public classifications
- refresh `fast-uri` lockfile version so `npm audit --omit=optional` passes

## Verification
- `npm test`
- `npm run check:fixtures`
- `npm run check:public-fixtures`
- `npm run check:schema-ids`
- `npm run check:spec-boundary`
- `npm audit --omit=optional`

Closes #52
Part of: #55