### PR TITLE
PROTOCOL-X3B-002: Define confidential reference fixture separation

### DIFF
--- a/docs/EIP-0003-audit-event.md
+++ b/docs/EIP-0003-audit-event.md
@@ -81,3 +81,7 @@ Track B customer / regulated events should follow
 `docs/integration/customer-regulated-data-classification-profile.md` before
 customer / regulated evidence production, validation, rejection, redaction, or
 handoff facts are accepted. Missing or unknown classification must fail closed.
+AuditEvent payloads may record sanitized confidential reference facts such as
+reference kind, checksum presence, producer boundary, and classification, but
+must not include the controlled material, raw credentials, customer records, or
+regulated record payloads.

--- a/docs/EIP-0004-evidence-bundle-ref.md
+++ b/docs/EIP-0004-evidence-bundle-ref.md
@@ -75,3 +75,9 @@ customer-system-derived output require an explicit classification before
 handling. Missing or unknown classification must fail closed instead of being
 inferred from URI shape, repository naming, tenant hints, or operator-facing
 summaries.
+
+The Track B profile also defines confidential reference expectations for stable
+id, URI or locator shape, checksum, producer metadata, and data classification.
+Those references point to controlled material; they do not authorize raw
+secret, credential, customer record, or regulated record payloads in public
+EvidenceBundleRef fixtures.

--- a/docs/integration/customer-regulated-data-classification-profile.md
+++ b/docs/integration/customer-regulated-data-classification-profile.md
@@ -65,6 +65,35 @@ customer data, regulated data, private repository details, raw secrets, or
 evidence bodies. For Track B, the reference handling boundary must have an
 explicit classification before the reference is used.
 
+A confidential reference is a reference to controlled material, not the
+controlled material itself. It may describe that a non-public artifact exists
+only through these bounded fields:
+
+- stable id: a durable synthetic identifier for the reference record, not a
+  customer identifier, tenant name, credential value, account id, repository
+  path, or regulated record id;
+- URI or locator: a placeholder or controlled-boundary locator such as
+  `<controlled-evidence-root>/...`, never a raw workstation-local absolute
+  path, live ERPNext URL, credential-bearing URI, private repository detail, or
+  exposed customer system path;
+- checksum: the digest algorithm and value for the controlled material when a
+  stable body exists, or an explicit producer reason when no stable body can be
+  digested;
+- producer metadata: bounded facts such as producer name, producer boundary,
+  protocol version, production time, and validation command, with no raw
+  secrets, credentials, tokens, private repository details, or workstation-local
+  paths;
+- data classification: the explicit `customer-confidential` or `regulated`
+  handling value for real controlled material, or `public` only when the value
+  is a synthetic public fixture example.
+
+Confidential references must be handled as not raw secret, not raw credential,
+not raw customer record, and not raw regulated record payloads. When any of the
+stable id, URI or locator, checksum expectation, producer metadata, or data
+classification signals are missing, malformed, or only inferred from nearby
+metadata, consumers should reject, quarantine, or route a follow-up instead of
+accepting the reference.
+
 AuditEvent should record append-only facts about classification, production,
 validation, rejection, redaction, and handoff. AuditEvent payloads may include
 `dataClassification`, redacted reference kind, producer boundary, checksum

--- a/docs/integration/operational-evidence-profile.md
+++ b/docs/integration/operational-evidence-profile.md
@@ -105,6 +105,12 @@ does not permit customer repo input, regulated data, live ERPNext write-back,
 electronic signatures, batch release, final disposition approval, or compliance
 claims.
 
+For Track B, that profile separates confidential references from public fixture
+examples. Loop, Flow, and Pharma artifact hygiene checks should cite it when
+public exports need to prove that confidential references carry only sanitized
+id, locator, checksum, producer metadata, and classification fields while the
+controlled material stays outside public fixtures.
+
 ## Conformance Example
 
 The public conformance example lives at

--- a/docs/protocol-snapshot-policy.md
+++ b/docs/protocol-snapshot-policy.md
@@ -37,7 +37,8 @@ Each consumer snapshot record should include:
 - customer / regulated classification profile: the
   `docs/integration/customer-regulated-data-classification-profile.md` guidance
   used when the copied snapshot includes Track B customer / regulated
-  classification evidence;
+  classification evidence, confidential reference examples, or public export
+  checks that prove controlled material stays outside public fixtures;
 - consumer owner: the local consumer test, task, or adapter boundary that reads
   the copied snapshot;
 - unsupported EIP major version evidence: sanitized evidence naming the

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -127,3 +127,10 @@ Use this example as copied or vendored conformance input:
 Loop, Flow, and Pharma consumers should use the example to verify that customer
 / regulated references require explicit classification and that missing or
 unknown classification stays blocked or routed instead of inferred.
+
+The example also includes a sanitized confidential reference shape. It shows a
+stable synthetic id, placeholder locator, checksum, producer metadata, and
+`public` fixture classification without storing the controlled material. Runtime
+repositories can cite that shape from artifact hygiene and public export checks,
+but real customer / regulated evidence references must remain in the controlled
+consumer boundary.

--- a/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
+++ b/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
@@ -42,9 +42,7 @@
       "boundary": "protocol-example",
       "producedAt": "2026-01-01T00:00:00Z"
     },
-    "dataClassification": "public",
-    "controlledMaterial": "reference only; controlled payload is not stored in public fixtures",
-    "publicFixtureContent": "synthetic metadata only; no raw client or regulated payload"
+    "dataClassification": "public"
   },
   "nonClaims": [
     "not production-ready",

--- a/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
+++ b/fixtures/customer-regulated-data-classification/v1/valid/public-safe-profile.json
@@ -30,6 +30,22 @@
     "containsWorkstationLocalAbsolutePath": false,
     "placeholderEvidenceRoot": "<evidence-root>/track-b/public-safe-example.json"
   },
+  "confidentialReferenceExample": {
+    "id": "confref_synthetic_0001",
+    "locator": "<controlled-evidence-root>/track-b/synthetic-reference.json",
+    "checksum": {
+      "algorithm": "sha256",
+      "value": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+    },
+    "producerMetadata": {
+      "producer": "synthetic-producer",
+      "boundary": "protocol-example",
+      "producedAt": "2026-01-01T00:00:00Z"
+    },
+    "dataClassification": "public",
+    "controlledMaterial": "reference only; controlled payload is not stored in public fixtures",
+    "publicFixtureContent": "synthetic metadata only; no raw client or regulated payload"
+  },
   "nonClaims": [
     "not production-ready",
     "not a validated system",

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -556,6 +556,24 @@ describe("integration handoff documentation", () => {
     );
     const snapshotPolicy = readDoc("docs/protocol-snapshot-policy.md");
     const fixturesReadme = readDoc("fixtures/README.md");
+    const example = readJson<{
+      confidentialReferenceExample: {
+        id: string;
+        locator: string;
+        checksum: {
+          algorithm: string;
+          value: string;
+        };
+        producerMetadata: {
+          producer: string;
+          boundary: string;
+          producedAt: string;
+        };
+        dataClassification: string;
+        controlledMaterial: string;
+        publicFixtureContent: string;
+      };
+    }>(examplePath);
 
     for (const expected of [
       "Track B customer / regulated data classification profile",
@@ -570,6 +588,17 @@ describe("integration handoff documentation", () => {
       "fail closed",
       "EvidenceBundleRef",
       "AuditEvent",
+      "confidential reference",
+      "controlled material",
+      "stable id",
+      "URI or locator",
+      "checksum",
+      "producer metadata",
+      "data classification",
+      "not raw secret",
+      "not raw credential",
+      "not raw customer record",
+      "not raw regulated record",
       "operational-evidence-profile.md",
       "fixture safety",
       "snapshot policy",
@@ -598,6 +627,24 @@ describe("integration handoff documentation", () => {
     }
 
     expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
+    expect(example.confidentialReferenceExample.id).toMatch(/^confref_/);
+    expect(example.confidentialReferenceExample.locator).toContain(
+      "<controlled-evidence-root>"
+    );
+    expect(example.confidentialReferenceExample.checksum.algorithm).toBe("sha256");
+    expect(example.confidentialReferenceExample.checksum.value).toMatch(
+      /^[0-9a-f]{64}$/
+    );
+    expect(example.confidentialReferenceExample.producerMetadata.producer).toBe(
+      "synthetic-producer"
+    );
+    expect(example.confidentialReferenceExample.dataClassification).toBe("public");
+    expect(example.confidentialReferenceExample.controlledMaterial).toContain(
+      "reference only"
+    );
+    expect(example.confidentialReferenceExample.publicFixtureContent).toContain(
+      "no raw client or regulated payload"
+    );
     expect(hasWorkstationHomePath(profile)).toBe(false);
   });
 });

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -24,6 +24,23 @@ function hasWorkstationHomePath(content: string): boolean {
   );
 }
 
+function asJsonObject(value: unknown, label: string): Record<string, unknown> {
+  expect(typeof value, `${label} must be an object`).toBe("object");
+  expect(value === null, `${label} must not be null`).toBe(false);
+  expect(Array.isArray(value), `${label} must not be an array`).toBe(false);
+  return value as Record<string, unknown>;
+}
+
+function requiredStringField(
+  record: Record<string, unknown>,
+  field: string
+): string {
+  const value = record[field];
+  expect(typeof value, `${field} must be a string`).toBe("string");
+  expect(value, `${field} must not be empty`).toMatch(/\S/);
+  return value as string;
+}
+
 describe("integration handoff documentation", () => {
   it("detects common workstation home path fragments", () => {
     expect(
@@ -556,22 +573,9 @@ describe("integration handoff documentation", () => {
     );
     const snapshotPolicy = readDoc("docs/protocol-snapshot-policy.md");
     const fixturesReadme = readDoc("fixtures/README.md");
-    const example = readJson<{
-      confidentialReferenceExample: {
-        id: string;
-        locator: string;
-        checksum: {
-          algorithm: string;
-          value: string;
-        };
-        producerMetadata: {
-          producer: string;
-          boundary: string;
-          producedAt: string;
-        };
-        dataClassification: string;
-      };
-    }>(examplePath);
+    const example = readJson<{ confidentialReferenceExample: unknown }>(
+      examplePath
+    );
 
     for (const expected of [
       "Track B customer / regulated data classification profile",
@@ -625,47 +629,47 @@ describe("integration handoff documentation", () => {
     }
 
     expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
-    expect(Object.keys(example.confidentialReferenceExample).sort()).toEqual([
+    const confidentialReferenceExample = asJsonObject(
+      example.confidentialReferenceExample,
+      "confidentialReferenceExample"
+    );
+    const checksum = asJsonObject(
+      confidentialReferenceExample.checksum,
+      "confidentialReferenceExample.checksum"
+    );
+    const producerMetadata = asJsonObject(
+      confidentialReferenceExample.producerMetadata,
+      "confidentialReferenceExample.producerMetadata"
+    );
+
+    expect(Object.keys(confidentialReferenceExample).sort()).toEqual([
       "checksum",
       "dataClassification",
       "id",
       "locator",
       "producerMetadata"
     ]);
-    expect(example.confidentialReferenceExample.id).toMatch(/^confref_/);
-    expect(example.confidentialReferenceExample.locator).toContain(
+    expect(requiredStringField(confidentialReferenceExample, "id")).toMatch(
+      /^confref_/
+    );
+    expect(requiredStringField(confidentialReferenceExample, "locator")).toContain(
       "<controlled-evidence-root>"
     );
-    expect(example.confidentialReferenceExample.checksum.algorithm).toBe("sha256");
-    expect(example.confidentialReferenceExample.checksum.value).toMatch(
+    expect(requiredStringField(checksum, "algorithm")).toBe("sha256");
+    expect(requiredStringField(checksum, "value")).toMatch(
       /^[0-9a-f]{64}$/
     );
-    expect(
-      typeof example.confidentialReferenceExample.producerMetadata.producer
-    ).toBe("string");
-    expect(
-      example.confidentialReferenceExample.producerMetadata.producer
-    ).toMatch(/\S/);
-    expect(
-      typeof example.confidentialReferenceExample.producerMetadata.boundary
-    ).toBe("string");
-    expect(
-      example.confidentialReferenceExample.producerMetadata.boundary
-    ).toMatch(/\S/);
-    expect(
-      example.confidentialReferenceExample.producerMetadata.producedAt
-    ).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
-    expect(
-      Number.isNaN(
-        Date.parse(example.confidentialReferenceExample.producerMetadata.producedAt)
-      )
-    ).toBe(false);
-    expect(
-      Object.keys(example.confidentialReferenceExample.producerMetadata).sort()
-    ).toEqual(
-      ["boundary", "producedAt", "producer"]
-    );
-    expect(example.confidentialReferenceExample.dataClassification).toBe("public");
+    requiredStringField(producerMetadata, "producer");
+    requiredStringField(producerMetadata, "boundary");
+    const producedAt = requiredStringField(producerMetadata, "producedAt");
+    expect(producedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(Number.isNaN(Date.parse(producedAt))).toBe(false);
+    expect(Object.keys(producerMetadata).sort()).toEqual([
+      "boundary",
+      "producedAt",
+      "producer"
+    ]);
+    expect(confidentialReferenceExample.dataClassification).toBe("public");
     expect(hasWorkstationHomePath(profile)).toBe(false);
   });
 });

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -570,8 +570,6 @@ describe("integration handoff documentation", () => {
           producedAt: string;
         };
         dataClassification: string;
-        controlledMaterial: string;
-        publicFixtureContent: string;
       };
     }>(examplePath);
 
@@ -627,6 +625,13 @@ describe("integration handoff documentation", () => {
     }
 
     expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
+    expect(Object.keys(example.confidentialReferenceExample).sort()).toEqual([
+      "checksum",
+      "dataClassification",
+      "id",
+      "locator",
+      "producerMetadata"
+    ]);
     expect(example.confidentialReferenceExample.id).toMatch(/^confref_/);
     expect(example.confidentialReferenceExample.locator).toContain(
       "<controlled-evidence-root>"
@@ -635,16 +640,32 @@ describe("integration handoff documentation", () => {
     expect(example.confidentialReferenceExample.checksum.value).toMatch(
       /^[0-9a-f]{64}$/
     );
-    expect(example.confidentialReferenceExample.producerMetadata.producer).toBe(
-      "synthetic-producer"
+    expect(
+      typeof example.confidentialReferenceExample.producerMetadata.producer
+    ).toBe("string");
+    expect(
+      example.confidentialReferenceExample.producerMetadata.producer
+    ).toMatch(/\S/);
+    expect(
+      typeof example.confidentialReferenceExample.producerMetadata.boundary
+    ).toBe("string");
+    expect(
+      example.confidentialReferenceExample.producerMetadata.boundary
+    ).toMatch(/\S/);
+    expect(
+      example.confidentialReferenceExample.producerMetadata.producedAt
+    ).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/);
+    expect(
+      Number.isNaN(
+        Date.parse(example.confidentialReferenceExample.producerMetadata.producedAt)
+      )
+    ).toBe(false);
+    expect(
+      Object.keys(example.confidentialReferenceExample.producerMetadata).sort()
+    ).toEqual(
+      ["boundary", "producedAt", "producer"]
     );
     expect(example.confidentialReferenceExample.dataClassification).toBe("public");
-    expect(example.confidentialReferenceExample.controlledMaterial).toContain(
-      "reference only"
-    );
-    expect(example.confidentialReferenceExample.publicFixtureContent).toContain(
-      "no raw client or regulated payload"
-    );
     expect(hasWorkstationHomePath(profile)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- define the Track B confidential reference contract as a controlled-material pointer with stable id, locator, checksum, producer metadata, and classification expectations
- extend the public-safe Track B fixture with a synthetic confidential reference example
- link the guidance from EvidenceBundleRef, AuditEvent, operational evidence, snapshot policy, and fixture docs

## Verification
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:schema-ids
- npm run check:spec-boundary
- npm audit --omit=optional

Refs #53
Part of #55