### PR TITLE
PROTOCOL-X3B-003: Define approval evidence semantics

### DIFF
--- a/docs/EIP-0003-audit-event.md
+++ b/docs/EIP-0003-audit-event.md
@@ -85,3 +85,11 @@ AuditEvent payloads may record sanitized confidential reference facts such as
 reference kind, checksum presence, producer boundary, and classification, but
 must not include the controlled material, raw credentials, customer records, or
 regulated record payloads.
+
+Track B approval events should follow
+`docs/integration/approval-and-draft-evidence-semantics.md` when recording
+approval-required, approved, rejected, revoked, or superseded evidence states.
+AuditEvent can describe a human approval point or draft-only action artifact,
+but the protocol event does not grant automatic quality decisions, live
+write-back approval, electronic signatures, batch release, final disposition,
+validated-system status, or compliance guarantees.

--- a/docs/EIP-0004-evidence-bundle-ref.md
+++ b/docs/EIP-0004-evidence-bundle-ref.md
@@ -81,3 +81,12 @@ id, URI or locator shape, checksum, producer metadata, and data classification.
 Those references point to controlled material; they do not authorize raw
 secret, credential, customer record, or regulated record payloads in public
 EvidenceBundleRef fixtures.
+
+For Track B approval and draft-only evidence guidance, use
+`docs/integration/approval-and-draft-evidence-semantics.md`. EvidenceBundleRef
+may point to bounded approval evidence, draft-only action artifacts, rejection
+notes, revocation records, or supersession records, but the reference does not
+turn draft evidence into a committed artifact or externally applied artifact.
+It also does not grant automatic quality decisions, live write-back approval,
+electronic signatures, batch release, final disposition, validated-system
+status, or compliance guarantees.

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,8 @@ Start here:
   evidence profile for Loop and Flow Track A artifact hygiene checks.
 - `docs/integration/customer-regulated-data-classification-profile.md` defines the
   Track B customer / regulated data classification profile.
+- `docs/integration/approval-and-draft-evidence-semantics.md` defines the
+  Track B approval and draft-only evidence semantics profile.
 - `integration/cross-repo-change-policy.md` defines the protocol-first
   cross-repo change process.
 - `security.md` defines security posture for protocol artifacts.

--- a/docs/integration/approval-and-draft-evidence-semantics.md
+++ b/docs/integration/approval-and-draft-evidence-semantics.md
@@ -1,0 +1,125 @@
+# Track B Approval and Draft-Only Evidence Semantics
+
+Track B approval and draft-only evidence semantics define shared protocol
+vocabulary that Loop, Flow, Pharma, and future consumers can cite when an
+artifact records a proposed action, a human approval point, or a later approval
+state.
+
+This profile is contract text only. It does not add a runtime approval engine,
+workflow implementation, connector, ERPNext integration, electronic signature
+service, batch release process, final disposition process, validated system, or
+compliance guarantee.
+
+## Approval Vocabulary
+
+Use these values when approval state must be represented in Track B artifacts:
+
+| Value | Meaning |
+| --- | --- |
+| `approval-required` | A human approval point is required before the action can be committed or externally applied. |
+| `approved` | The required human approval point has been recorded by the authoritative workflow boundary. |
+| `rejected` | The proposed action or evidence was declined and must not be treated as approved or applied. |
+| `revoked` | A previously recorded approval was withdrawn by the authoritative workflow boundary. |
+| `superseded` | A newer proposal, approval record, or evidence record replaces this one for future handling. |
+
+These values describe evidence state. They do not make the protocol the final
+quality decision maker. Consumers must resolve authority, actor eligibility,
+tenant or repository scope, electronic record requirements, and final
+disposition rules in their own runtime or validation package boundary.
+
+## Draft-Only Action Artifacts
+
+A draft-only action artifact records an intended action before it is committed
+or externally applied. It is useful for read-only review, draft workflow
+planning, and evidence handoff where the protocol needs to describe the
+proposal without granting permission to mutate an external system.
+
+A draft-only action artifact should make these facts explicit:
+
+- the action intent is draft-only;
+- the external application state is not-applied;
+- the approval state is either `approval-required`, `rejected`, `revoked`, or
+  `superseded` until the authoritative workflow boundary records `approved`;
+- the artifact is not a committed artifact and not an externally applied
+  artifact;
+- any customer / regulated data classification follows
+  `customer-regulated-data-classification-profile.md`.
+
+A committed artifact is evidence that the producer boundary accepted the action
+as part of its durable state. An externally applied artifact is evidence that a
+consumer or connector boundary applied the action outside the protocol artifact
+itself. The protocol can reference those facts, but it does not perform the
+commit or external write-back.
+
+## AuditEvent Usage
+
+AuditEvent may record append-only facts about approval-required, approved,
+rejected, revoked, or superseded evidence. Event types should name the owning
+consumer namespace, for example `flow.approval.required` or
+`pharma.approval.rejected`.
+
+AuditEvent payloads should include bounded fields such as approval state,
+draft-only intent, not-applied external state, approver or reviewer reference,
+decision time, superseded reference id, rejection reason category, or revoked
+approval reference. They must not contain raw secrets, credentials, customer
+records, regulated record payloads, private repository details, live write-back
+tokens, electronic signature material, batch release records, final disposition
+records, or workstation-local absolute paths.
+
+Rejected, revoked, and superseded states are new append-only facts. Consumers
+should not edit older events to make them look as if they were never required
+or never approved.
+
+## EvidenceBundleRef Usage
+
+EvidenceBundleRef may point to a bounded approval evidence body, draft-only
+action artifact, rejection note, revocation record, or supersession record. The
+reference remains a reference artifact only; it does not embed the evidence
+body and does not prove the body is authorized for the current consumer.
+
+EvidenceBundleRef metadata may include public descriptors such as
+`approvalState`, `artifactIntent`, `externalApplicationState`,
+`supersedesRef`, or `decisionBoundary` when those values are synthetic,
+bounded, and safe for the exchange. Customer / regulated references require the
+Track B classification profile before they are handled.
+
+If provenance, approval authority, actor eligibility, scope binding,
+classification, or evidence boundary signals are missing or malformed,
+consumers should fail closed by rejecting, blocking, quarantining, or routing a
+follow-up instead of inferring approval from nearby names, path shape, comments,
+issue text, or operator-facing summaries.
+
+## Public Fixture Safety
+
+Public examples for this profile must remain synthetic and publishable. They
+must not contain customer data, regulated data, raw secrets, credentials,
+access tokens, private repository details, workstation-local absolute paths,
+live ERPNext write-back targets, electronic signature records, batch release
+records, final disposition records, or real external mutation evidence.
+
+Use placeholders such as `<approval-boundary>`, `<reviewer-ref>`,
+`<controlled-evidence-root>`, `<repository-ref>`, and
+`<supervisor-config-path>` when an example needs to name a boundary without
+exposing local or private state.
+
+The public-safe conformance example lives at
+`fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json`.
+It is fixture-like guidance, not a new EIP schema family.
+
+## Track B Non-Claims
+
+This profile gives downstream consumers a shared vocabulary for approval
+evidence. It is:
+
+- not automatic quality decision support;
+- not live write-back approval;
+- not electronic signature;
+- not batch release;
+- not final disposition;
+- not a validated system;
+- not a compliance guarantee.
+
+Loop, Flow, Pharma, and future consumers remain responsible for runtime
+authorization, human review UX, electronic record controls, quality decisions,
+customer boundary enforcement, regulated workflow controls, connector behavior,
+storage, retention, and validation evidence.

--- a/docs/integration/customer-regulated-data-classification-profile.md
+++ b/docs/integration/customer-regulated-data-classification-profile.md
@@ -110,6 +110,13 @@ The protocol snapshot policy in `docs/protocol-snapshot-policy.md` should name
 this profile when a copied snapshot includes Track B customer / regulated
 classification docs, fixtures, or downstream conformance evidence.
 
+Approval-required, approved, rejected, revoked, superseded, and draft-only
+action evidence should also follow
+`docs/integration/approval-and-draft-evidence-semantics.md`. Classification is
+still required for customer / regulated approval evidence, and approval state
+must not be inferred from names, paths, comments, issue text, operator
+summaries, or nearby metadata.
+
 ## Public Fixture Safety
 
 Public examples for this profile must remain synthetic and publishable. They

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -31,6 +31,10 @@ placeholders for credentials, tenants, hosts, and operator-specific values.
   Track B classification profile examples for
   `docs/integration/customer-regulated-data-classification-profile.md`. These
   examples are fixture-like guidance, not a new EIP schema family.
+- `approval-evidence-semantics/v1/valid/` contains public-safe Track B approval
+  and draft-only evidence semantics examples for
+  `docs/integration/approval-and-draft-evidence-semantics.md`. These examples
+  are fixture-like guidance, not a new EIP schema family.
 
 ## X-Gate 2 Loop-Flow Dry-Run Smoke
 
@@ -134,3 +138,23 @@ stable synthetic id, placeholder locator, checksum, producer metadata, and
 repositories can cite that shape from artifact hygiene and public export checks,
 but real customer / regulated evidence references must remain in the controlled
 consumer boundary.
+
+## Track B Approval and Draft-Only Evidence Example
+
+Track B adds public-safe approval and draft-only evidence examples for shared
+approval vocabulary and draft-only workflow evidence. The examples do not
+contain customer data, regulated data, raw secrets, credentials, private
+repository details, workstation-local absolute paths, live write-back records,
+electronic signature records, batch release records, or final disposition
+records.
+
+Use this example as copied or vendored conformance input:
+
+| Example | Covered behavior |
+| --- | --- |
+| `fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json` | approval-required, approved, rejected, revoked, and superseded vocabulary; draft-only action artifact handling; AuditEvent and EvidenceBundleRef usage; and non-claims |
+
+Loop, Flow, and Pharma consumers should use the example to verify that a
+draft-only action artifact remains not-applied until the authoritative workflow
+boundary records approval, and that rejected, revoked, or superseded evidence
+stays represented as append-only evidence instead of inferred success.

--- a/fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json
+++ b/fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json
@@ -1,0 +1,55 @@
+{
+  "profile": "Track B approval and draft-only evidence semantics",
+  "schemaVersion": "approval-evidence-semantics.example.v1",
+  "dataClassification": "public",
+  "approvalVocabulary": [
+    "approval-required",
+    "approved",
+    "rejected",
+    "revoked",
+    "superseded"
+  ],
+  "draftOnlyActionArtifact": {
+    "id": "draft_action_01HX3K7Y2H5N8R4P9Q6M1A2B3C",
+    "intent": "draft-only",
+    "approvalState": "approval-required",
+    "externalApplicationState": "not-applied",
+    "subjectRef": "<repository-ref>",
+    "approvalBoundary": "<approval-boundary>",
+    "reviewerRef": "<reviewer-ref>"
+  },
+  "auditEventUsage": {
+    "schemaVersion": "eip.audit-event.v1",
+    "type": "flow.approval.required",
+    "payloadShape": {
+      "approvalState": "approval-required",
+      "artifactIntent": "draft-only",
+      "externalApplicationState": "not-applied",
+      "decisionBoundary": "<approval-boundary>"
+    }
+  },
+  "evidenceBundleRefUsage": {
+    "schemaVersion": "eip.evidence-bundle-ref.v1",
+    "type": "local_path",
+    "uri": "fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json",
+    "metadataShape": {
+      "approvalState": "approval-required",
+      "artifactIntent": "draft-only",
+      "externalApplicationState": "not-applied"
+    }
+  },
+  "rejectedRevokedSupersededHandling": {
+    "rejected": "append a rejected evidence fact and keep the action not-applied",
+    "revoked": "append a revoked evidence fact and require a new authoritative approval before applying",
+    "superseded": "append a superseded evidence fact that points to the newer authoritative reference"
+  },
+  "nonClaims": [
+    "not automatic quality decision",
+    "not live write-back approval",
+    "not electronic signature",
+    "not batch release",
+    "not final disposition",
+    "not a validated system",
+    "not a compliance guarantee"
+  ]
+}

--- a/test/integration-docs.test.ts
+++ b/test/integration-docs.test.ts
@@ -672,4 +672,81 @@ describe("integration handoff documentation", () => {
     expect(confidentialReferenceExample.dataClassification).toBe("public");
     expect(hasWorkstationHomePath(profile)).toBe(false);
   });
+
+  it("documents Track B approval and draft-only evidence semantics", () => {
+    const profilePath =
+      "docs/integration/approval-and-draft-evidence-semantics.md";
+    const examplePath =
+      "fixtures/approval-evidence-semantics/v1/valid/public-safe-draft-action.json";
+    const profile = readDoc(profilePath);
+    const docsIndex = readDoc("docs/README.md");
+    const evidenceRef = readDoc("docs/EIP-0004-evidence-bundle-ref.md");
+    const auditEvent = readDoc("docs/EIP-0003-audit-event.md");
+    const classificationProfile = readDoc(
+      "docs/integration/customer-regulated-data-classification-profile.md"
+    );
+    const fixturesReadme = readDoc("fixtures/README.md");
+    const example = readJson<{
+      approvalVocabulary: string[];
+      draftOnlyActionArtifact: Record<string, unknown>;
+      auditEventUsage: Record<string, unknown>;
+      evidenceBundleRefUsage: Record<string, unknown>;
+      nonClaims: string[];
+    }>(examplePath);
+
+    for (const expected of [
+      "Track B approval and draft-only evidence semantics",
+      "approval-required",
+      "approved",
+      "rejected",
+      "revoked",
+      "superseded",
+      "draft-only action artifact",
+      "committed artifact",
+      "externally applied artifact",
+      "AuditEvent",
+      "EvidenceBundleRef",
+      "human approval point",
+      "not automatic quality decision",
+      "not live write-back approval",
+      "not electronic signature",
+      "not batch release",
+      "not final disposition",
+      "not a validated system",
+      "not a compliance guarantee",
+      examplePath
+    ]) {
+      expect(profile).toContain(expected);
+    }
+
+    for (const linkedDoc of [
+      docsIndex,
+      evidenceRef,
+      auditEvent,
+      classificationProfile,
+      fixturesReadme
+    ]) {
+      expect(linkedDoc).toContain(profilePath);
+    }
+
+    expect(existsSync(path.join(repoRoot, examplePath))).toBe(true);
+    expect(example.approvalVocabulary).toEqual([
+      "approval-required",
+      "approved",
+      "rejected",
+      "revoked",
+      "superseded"
+    ]);
+    expect(example.draftOnlyActionArtifact.intent).toBe("draft-only");
+    expect(example.draftOnlyActionArtifact.externalApplicationState).toBe(
+      "not-applied"
+    );
+    expect(example.auditEventUsage.type).toBe("flow.approval.required");
+    expect(example.evidenceBundleRefUsage.uri).toContain(
+      "fixtures/approval-evidence-semantics/"
+    );
+    expect(example.nonClaims).toContain("not live write-back approval");
+    expect(example.nonClaims).toContain("not electronic signature");
+    expect(hasWorkstationHomePath(profile + JSON.stringify(example))).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add Track B approval and draft-only evidence semantics profile
- add public-safe draft action fixture-like example
- link the profile from AuditEvent, EvidenceBundleRef, Track B classification docs, docs index, and fixture index

## Verification
- npm test -- test/integration-docs.test.ts
- npm test
- npm run check:fixtures
- npm run check:public-fixtures
- npm run check:schema-ids
- npm run check:spec-boundary
- npm audit --omit=optional

Closes #54